### PR TITLE
Point Slack badge to Pion Slack info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <h4 align="center">Go implementation of a WebRTC SFU</h4>
 <p align="center">
-  <a href="http://gophers.slack.com/messages/pion"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen" alt="Slack Widget"></a>
+  <a href="https://pion.ly/slack"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen" alt="Slack Widget"></a>
   <a href="https://travis-ci.org/pion/ion-sfu"><img src="https://travis-ci.org/pion/ion-sfu.svg?branch=master" alt="Build Status"></a>
   <a href="https://pkg.go.dev/github.com/pion/ion-sfu"><img src="https://godoc.org/github.com/pion/ion-sfu?status.svg" alt="GoDoc"></a>
   <a href="https://codecov.io/gh/pion/ion-sfu"><img src="https://codecov.io/gh/pion/ion-sfu/branch/master/graph/badge.svg" alt="Coverage Status"></a>


### PR DESCRIPTION
The current link doesn't include the invite link or any info on how to get to it. 

The updated one is the same link that's used on the main pion/ion repo.

Might save the next person 10 minutes :)