### PR TITLE
Add session to transport

### DIFF
--- a/cmd/server/grpc/main.go
+++ b/cmd/server/grpc/main.go
@@ -182,19 +182,13 @@ func (s *server) Signal(stream pb.SFU_SignalServer) error {
 				SDP:  string(payload.Join.Offer.Sdp),
 			}
 
-			peer, err = sfu.NewWebRTCTransport(offer)
+			peer, err = s.sfu.NewWebRTCTransport(payload.Join.Sid, offer)
 			if err != nil {
 				log.Errorf("join error: %v", err)
 				return status.Errorf(codes.InvalidArgument, "join error %s", err)
 			}
 
 			log.Infof("peer %s join session %s", peer.ID(), payload.Join.Sid)
-
-			session := s.sfu.GetSession(payload.Join.Sid)
-			if session == nil {
-				session = s.sfu.NewSession(payload.Join.Sid)
-			}
-			session.AddTransport(peer)
 
 			err = peer.SetRemoteDescription(offer)
 			if err != nil {

--- a/cmd/server/json-rpc/main.go
+++ b/cmd/server/json-rpc/main.go
@@ -161,7 +161,7 @@ func (r *RPC) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Req
 			break
 		}
 
-		peer, err := sfu.NewWebRTCTransport(join.Offer)
+		peer, err := r.sfu.NewWebRTCTransport(join.Sid, join.Offer)
 
 		if err != nil {
 			log.Errorf("connect: error creating peer: %v", err)
@@ -173,12 +173,6 @@ func (r *RPC) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Req
 		}
 
 		log.Infof("peer %s join session %s", peer.ID(), join.Sid)
-
-		session := r.sfu.GetSession(join.Sid)
-		if session == nil {
-			session = r.sfu.NewSession(join.Sid)
-		}
-		session.AddTransport(peer)
 
 		err = peer.SetRemoteDescription(join.Offer)
 		if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/buffer.go
+++ b/pkg/buffer.go
@@ -83,7 +83,7 @@ func NewBuffer(ssrc uint32, pt uint8, o BufferOptions) *Buffer {
 	}
 	b.maxBufferTS = uint32(o.BufferTime) * videoClock / 1000
 	// b.bufferStartTS = time.Now()
-	log.Infof("NewBuffer BufferOptions=%v", o)
+	log.Debugf("NewBuffer BufferOptions=%v", o)
 	return b
 }
 

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -11,6 +11,7 @@ import (
 
 // Router defines a track rtp/rtcp router
 type Router struct {
+	tid      string
 	stop     bool
 	mu       sync.RWMutex
 	receiver Receiver
@@ -18,8 +19,9 @@ type Router struct {
 }
 
 // NewRouter for routing rtp/rtcp packets
-func NewRouter(recv Receiver) *Router {
+func NewRouter(tid string, recv Receiver) *Router {
 	r := &Router{
+		tid:      tid,
 		receiver: recv,
 		senders:  make(map[string]Sender),
 	}
@@ -52,6 +54,7 @@ func (r *Router) DelSub(pid string) {
 
 // Close a router
 func (r *Router) Close() {
+	log.Debugf("Router close")
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.stop = true
@@ -84,6 +87,7 @@ func (r *Router) start() {
 			continue
 		}
 
+		r.mu.RLock()
 		// Push to sub send queues
 		r.mu.RLock()
 		for _, sub := range r.senders {

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -87,7 +87,6 @@ func (r *Router) start() {
 			continue
 		}
 
-		r.mu.RLock()
 		// Push to sub send queues
 		r.mu.RLock()
 		for _, sub := range r.senders {

--- a/pkg/router_test.go
+++ b/pkg/router_test.go
@@ -63,6 +63,7 @@ func TestRouter(t *testing.T) {
 
 		// add sub back to test close
 		router.AddSender(subPid, sender)
+		assert.Contains(t, router.stats(), "router:")
 		router.Close()
 		assert.Len(t, router.senders, 0)
 		assert.True(t, sender.stop)
@@ -91,7 +92,7 @@ func TestRouterPartialReadCanClose(t *testing.T) {
 	onReadRTPFired, onReadRTPFiredFunc := context.WithCancel(context.Background())
 	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
 		receiver := NewWebRTCVideoReceiver(WebRTCVideoReceiverConfig{}, track)
-		router := NewRouter(receiver)
+		router := NewRouter("id", receiver)
 		subsfu, sub, err := newPair(webrtc.Configuration{}, api)
 		assert.NoError(t, err)
 

--- a/pkg/router_test.go
+++ b/pkg/router_test.go
@@ -24,7 +24,7 @@ func TestRouter(t *testing.T) {
 	onReadRTPFired, onReadRTPFiredFunc := context.WithCancel(context.Background())
 	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
 		receiver := NewWebRTCVideoReceiver(WebRTCVideoReceiverConfig{}, track)
-		router := NewRouter(receiver)
+		router := NewRouter("id", receiver)
 		assert.Equal(t, router.receiver, receiver)
 
 		subsfu, sub, err := newPair(webrtc.Configuration{}, api)

--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -43,11 +43,11 @@ func NewWebRTCSender(track Track, sender *webrtc.RTPSender) *WebRTCSender {
 	for _, feedback := range track.Codec().RTCPFeedback {
 		switch feedback.Type {
 		case webrtc.TypeRTCPFBGoogREMB:
-			log.Infof("Using sender feedback %s", webrtc.TypeRTCPFBGoogREMB)
+			log.Debugf("Using sender feedback %s", webrtc.TypeRTCPFBGoogREMB)
 			s.useRemb = true
 			go s.rembLoop()
 		case webrtc.TypeRTCPFBTransportCC:
-			log.Infof("Using sender feedback %s", webrtc.TypeRTCPFBTransportCC)
+			log.Debugf("Using sender feedback %s", webrtc.TypeRTCPFBTransportCC)
 			// TODO
 		}
 	}

--- a/pkg/sfu_test.go
+++ b/pkg/sfu_test.go
@@ -1,30 +1,23 @@
 package sfu
 
-import (
-	"testing"
+// func TestSFU(t *testing.T) {
+// 	s := NewSFU(Config{
+// 		Log: log.Config{
+// 			Level: "error",
+// 		},
+// 		WebRTC: WebRTCConfig{},
+// 		Receiver: ReceiverConfig{
+// 			Video: WebRTCVideoReceiverConfig{},
+// 		},
+// 	})
 
-	"github.com/pion/ion-sfu/pkg/log"
-	"github.com/stretchr/testify/assert"
-)
+// 	session := s.NewSession("test session")
+// 	assert.NotNil(t, session)
+// 	assert.Len(t, s.sessions, 1)
 
-func TestSFU(t *testing.T) {
-	s := NewSFU(Config{
-		Log: log.Config{
-			Level: "error",
-		},
-		WebRTC: WebRTCConfig{},
-		Receiver: ReceiverConfig{
-			Video: WebRTCVideoReceiverConfig{},
-		},
-	})
+// 	assert.Equal(t, session, s.GetSession("test session"))
 
-	session := s.NewSession("test session")
-	assert.NotNil(t, session)
-	assert.Len(t, s.sessions, 1)
-
-	assert.Equal(t, session, s.GetSession("test session"))
-
-	session.onCloseHandler()
-	assert.Nil(t, s.GetSession("test session"))
-	assert.Len(t, s.sessions, 0)
-}
+// 	session.onCloseHandler()
+// 	assert.Nil(t, s.GetSession("test session"))
+// 	assert.Len(t, s.sessions, 0)
+// }

--- a/pkg/sfu_test.go
+++ b/pkg/sfu_test.go
@@ -1,23 +1,36 @@
 package sfu
 
-// func TestSFU(t *testing.T) {
-// 	s := NewSFU(Config{
-// 		Log: log.Config{
-// 			Level: "error",
-// 		},
-// 		WebRTC: WebRTCConfig{},
-// 		Receiver: ReceiverConfig{
-// 			Video: WebRTCVideoReceiverConfig{},
-// 		},
-// 	})
+import (
+	"testing"
 
-// 	session := s.NewSession("test session")
-// 	assert.NotNil(t, session)
-// 	assert.Len(t, s.sessions, 1)
+	"github.com/pion/ion-sfu/pkg/log"
+	"github.com/pion/webrtc/v3"
+	"github.com/stretchr/testify/assert"
+)
 
-// 	assert.Equal(t, session, s.GetSession("test session"))
+func TestSFU(t *testing.T) {
+	s := NewSFU(Config{
+		Log: log.Config{
+			Level: "error",
+		},
+		WebRTC: WebRTCConfig{},
+		Receiver: ReceiverConfig{
+			Video: WebRTCVideoReceiverConfig{},
+		},
+	})
 
-// 	session.onCloseHandler()
-// 	assert.Nil(t, s.GetSession("test session"))
-// 	assert.Len(t, s.sessions, 0)
-// }
+	me := webrtc.MediaEngine{}
+	me.RegisterDefaultCodecs()
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(me))
+	remote, err := api.NewPeerConnection(cfg)
+	assert.NoError(t, err)
+
+	offer, err := remote.CreateOffer(nil)
+	assert.NoError(t, err)
+	err = remote.SetLocalDescription(offer)
+	assert.NoError(t, err)
+
+	transport, err := s.NewWebRTCTransport("test session", offer)
+	assert.NotNil(t, transport)
+	assert.NoError(t, err)
+}

--- a/pkg/transport.go
+++ b/pkg/transport.go
@@ -4,10 +4,9 @@ package sfu
 // that media can be sent over
 type Transport interface {
 	ID() string
+	GetRouter(uint32) *Router
 	Routers() map[uint32]*Router
 	AddSub(transport Transport)
 	NewSender(Track) (Sender, error)
-	OnClose(f func())
-	OnRouter(f func(router *Router))
 	stats() string
 }

--- a/pkg/transport.go
+++ b/pkg/transport.go
@@ -6,7 +6,6 @@ type Transport interface {
 	ID() string
 	GetRouter(uint32) *Router
 	Routers() map[uint32]*Router
-	AddSub(transport Transport)
 	NewSender(Track) (Sender, error)
 	stats() string
 }

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -202,20 +202,6 @@ func (p *WebRTCTransport) NewSender(intrack Track) (Sender, error) {
 	return sender, nil
 }
 
-// AddSub adds peer as a sub
-func (p *WebRTCTransport) AddSub(t Transport) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	for _, router := range p.routers {
-		sender, err := t.NewSender(router.Track())
-		if err != nil {
-			log.Errorf("Error subscribing transport %s to router %v", t.ID(), router)
-		}
-		router.AddSender(t.ID(), sender)
-	}
-}
-
 // ID of peer
 func (p *WebRTCTransport) ID() string {
 	return p.id

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -23,14 +23,13 @@ type WebRTCTransport struct {
 	me                         MediaEngine
 	mu                         sync.RWMutex
 	stop                       bool
+	session                    *Session
 	routers                    map[uint32]*Router
-	onCloseHandler             func()
 	onNegotiationNeededHandler func()
-	onRouterHander             func(*Router)
 }
 
 // NewWebRTCTransport creates a new WebRTCTransport
-func NewWebRTCTransport(offer webrtc.SessionDescription) (*WebRTCTransport, error) {
+func NewWebRTCTransport(session *Session, offer webrtc.SessionDescription) (*WebRTCTransport, error) {
 	// We make our own mediaEngine so we can place the sender's codecs in it.  This because we must use the
 	// dynamic media type from the sender in our answer. This is not required if we are the offerer
 	me := MediaEngine{}
@@ -50,7 +49,23 @@ func NewWebRTCTransport(offer webrtc.SessionDescription) (*WebRTCTransport, erro
 		id:      cuid.New(),
 		pc:      pc,
 		me:      me,
+		session: session,
 		routers: make(map[uint32]*Router),
+	}
+
+	session.AddTransport(p)
+
+	// Subscribe to existing transports
+	for _, t := range session.Transports() {
+		log.Infof("transport %s", t.ID())
+		for _, router := range t.Routers() {
+			sender, err := p.NewSender(router.Track())
+			log.Infof("Init add router ssrc %d to %s", router.Track().SSRC(), p.id)
+			if err != nil {
+				log.Errorf("Error subscribing to router %v", router)
+			}
+			router.AddSender(p.id, sender)
+		}
 	}
 
 	pc.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
@@ -67,28 +82,25 @@ func NewWebRTCTransport(offer webrtc.SessionDescription) (*WebRTCTransport, erro
 			go p.sendRTCP(recv)
 		}
 
-		router := NewRouter(recv)
+		router := NewRouter(p.id, recv)
+		log.Debugf("Created router %s %d", p.id, recv.Track().SSRC())
+
+		p.session.AddRouter(router)
 
 		p.mu.Lock()
 		p.routers[recv.Track().SSRC()] = router
 		p.mu.Unlock()
-
-		log.Debugf("Create router %s %d", p.id, recv.Track().SSRC())
-
-		if p.onRouterHander != nil {
-			p.onRouterHander(router)
-		}
 	})
 
 	pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
-		log.Infof("ice connection state: %s", connectionState)
+		log.Debugf("ice connection state: %s", connectionState)
 		switch connectionState {
 		case webrtc.ICEConnectionStateDisconnected:
-			log.Infof("webrtc ice disconnected for peer: %s", p.id)
+			log.Debugf("webrtc ice disconnected for peer: %s", p.id)
 		case webrtc.ICEConnectionStateFailed:
 			fallthrough
 		case webrtc.ICEConnectionStateClosed:
-			log.Infof("webrtc ice closed for peer: %s", p.id)
+			log.Debugf("webrtc ice closed for peer: %s", p.id)
 			p.Close()
 		}
 	})
@@ -138,18 +150,6 @@ func (p *WebRTCTransport) SetRemoteDescription(desc webrtc.SessionDescription) e
 	}
 
 	return nil
-}
-
-// OnClose is called when the peer is closed
-func (p *WebRTCTransport) OnClose(f func()) {
-	p.onCloseHandler = f
-}
-
-// OnRouter handler called when a router is added
-func (p *WebRTCTransport) OnRouter(f func(*Router)) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.onRouterHander = f
 }
 
 // AddICECandidate to peer connection
@@ -228,6 +228,13 @@ func (p *WebRTCTransport) Routers() map[uint32]*Router {
 	return p.routers
 }
 
+// GetRouter returns router with ssrc
+func (p *WebRTCTransport) GetRouter(ssrc uint32) *Router {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.routers[ssrc]
+}
+
 // Close peer
 func (p *WebRTCTransport) Close() error {
 	p.mu.Lock()
@@ -241,9 +248,7 @@ func (p *WebRTCTransport) Close() error {
 		router.Close()
 	}
 
-	if p.onCloseHandler != nil {
-		p.onCloseHandler()
-	}
+	p.session.RemoveTransport(p.id)
 	p.stop = true
 	return p.pc.Close()
 }


### PR DESCRIPTION
Updating api so transport is aware of the session it belongs to. This is necessary for relay but also simplifies things and makes it explicit that a peer can only belong to a single session at a time