### PR TITLE
Send ICECandidate using ToJSON()

### DIFF
--- a/cmd/server/json-rpc/main.go
+++ b/cmd/server/json-rpc/main.go
@@ -212,7 +212,7 @@ func (r *RPC) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Req
 				return
 			}
 
-			if err := conn.Notify(ctx, "trickle", c.String()); err != nil {
+			if err := conn.Notify(ctx, "trickle", c.ToJSON()); err != nil {
 				log.Errorf("error sending trickle %s", err)
 			}
 		})


### PR DESCRIPTION
Send ICECandidate using `ToJSON()` rather than `String()`, same as in the grpc server. 
`ToJSON()` returns `sdpMLineIndex`  along with the `candidate` string, where as `String()` only returns the `candidate` string.