### PR TITLE
Expose OnTrack and OnConnectionStateChange handlers.

### DIFF
--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -170,6 +170,16 @@ func (p *WebRTCTransport) OnNegotiationNeeded(f func()) {
 	}
 }
 
+// OnTrack handler
+func (p *WebRTCTransport) OnTrack(f func(*webrtc.Track, *webrtc.RTPReceiver)) {
+	p.pc.OnTrack(f)
+}
+
+// OnConnectionStateChange handler
+func (p *WebRTCTransport) OnConnectionStateChange(f func(webrtc.PeerConnectionState)) {
+	p.pc.OnConnectionStateChange(f)
+}
+
 // NewSender for peer
 func (p *WebRTCTransport) NewSender(intrack Track) (Sender, error) {
 	to := p.me.GetCodecsByName(intrack.Codec().Name)

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -164,11 +164,15 @@ func (p *WebRTCTransport) AddICECandidate(candidate webrtc.ICECandidateInit) err
 
 // OnICECandidate handler
 func (p *WebRTCTransport) OnICECandidate(f func(c *webrtc.ICECandidate)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.pc.OnICECandidate(f)
 }
 
 // OnNegotiationNeeded handler
 func (p *WebRTCTransport) OnNegotiationNeeded(f func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	var debounced = util.NewDebouncer(500 * time.Millisecond)
 	p.onNegotiationNeededHandler = func() {
 		debounced(f)
@@ -177,11 +181,15 @@ func (p *WebRTCTransport) OnNegotiationNeeded(f func()) {
 
 // OnTrack handler
 func (p *WebRTCTransport) OnTrack(f func(*webrtc.Track, *webrtc.RTPReceiver)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.onTrackHandler = f
 }
 
 // OnConnectionStateChange handler
 func (p *WebRTCTransport) OnConnectionStateChange(f func(webrtc.PeerConnectionState)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.pc.OnConnectionStateChange(f)
 }
 

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -90,11 +90,11 @@ func NewWebRTCTransport(session *Session, offer webrtc.SessionDescription) (*Web
 
 		p.mu.Lock()
 		p.routers[recv.Track().SSRC()] = router
-		p.mu.Unlock()
 
 		if p.onTrackHandler != nil {
 			p.onTrackHandler(track, receiver)
 		}
+		p.mu.Unlock()
 	})
 
 	pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -164,8 +164,6 @@ func (p *WebRTCTransport) AddICECandidate(candidate webrtc.ICECandidateInit) err
 
 // OnICECandidate handler
 func (p *WebRTCTransport) OnICECandidate(f func(c *webrtc.ICECandidate)) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.pc.OnICECandidate(f)
 }
 
@@ -188,8 +186,6 @@ func (p *WebRTCTransport) OnTrack(f func(*webrtc.Track, *webrtc.RTPReceiver)) {
 
 // OnConnectionStateChange handler
 func (p *WebRTCTransport) OnConnectionStateChange(f func(webrtc.PeerConnectionState)) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.pc.OnConnectionStateChange(f)
 }
 

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -26,6 +26,7 @@ type WebRTCTransport struct {
 	session                    *Session
 	routers                    map[uint32]*Router
 	onNegotiationNeededHandler func()
+	onTrackHandler             func(*webrtc.Track, *webrtc.RTPReceiver)
 }
 
 // NewWebRTCTransport creates a new WebRTCTransport
@@ -90,6 +91,10 @@ func NewWebRTCTransport(session *Session, offer webrtc.SessionDescription) (*Web
 		p.mu.Lock()
 		p.routers[recv.Track().SSRC()] = router
 		p.mu.Unlock()
+
+		if p.onTrackHandler != nil {
+			p.onTrackHandler(track, receiver)
+		}
 	})
 
 	pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
@@ -172,7 +177,7 @@ func (p *WebRTCTransport) OnNegotiationNeeded(f func()) {
 
 // OnTrack handler
 func (p *WebRTCTransport) OnTrack(f func(*webrtc.Track, *webrtc.RTPReceiver)) {
-	p.pc.OnTrack(f)
+	p.onTrackHandler = f
 }
 
 // OnConnectionStateChange handler


### PR DESCRIPTION
These are necessary so the biz node gets a signal when a new track is emitted to associate it with a uid and so the biz node can disconnect clients that end up in a terminal PeerConnectionState automatically.