### PR TITLE
update ci, dont push docker latest for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ _build_sfu_docker_job: &build_sfu_docker_job
     - docker tag pionwebrtc/ion-sfu:latest pionwebrtc/ion-sfu:"$TRAVIS_TAG"
   deploy:
     provider: script
-    script: docker push pionwebrtc/ion-sfu:latest && docker push pionwebrtc/ion-sfu:"$TRAVIS_TAG"
+    script: docker push pionwebrtc/ion-sfu:"$TRAVIS_TAG"
+    # script: docker push pionwebrtc/ion-sfu:latest && docker push pionwebrtc/ion-sfu:"$TRAVIS_TAG"
     on:
       tags: true
 
@@ -48,36 +49,11 @@ _test_job: &test_job
   env: CACHE_NAME=test
   before_install:
     - if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
-  install:
-    - make nodes
   script:
     - make test
     - if [ -n "${TEST_HOOK}" ]; then ${TEST_HOOK}; fi
   after_success:
     - travis_retry bash <(curl -s https://codecov.io/bash) -c -F go
-_test_i386_job: &test_i386_job
-  env: CACHE_NAME=test386
-  services: docker
-  before_install:
-    - if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
-  before_script:
-    - make start_test_services
-  script:
-    - testpkgs=${TEST_PACKAGES:-$(go list ./... | grep -v cmd | grep -v conf)}
-    - |
-      docker run \
-        -u $(id -u):$(id -g) \
-        -e "GO111MODULE=on" \
-        -e "CGO_ENABLED=0" \
-        -v ${PWD}:/go/src/github.com/pion/$(basename ${PWD}) \
-        -v ${HOME}/gopath/pkg/mod:/go/pkg/mod \
-        -v ${HOME}/.cache/go-build:/.cache/go-build \
-        -w /go/src/github.com/pion/$(basename ${PWD}) \
-        --network ion_default \
-        -it i386/golang:${GO_VERSION}-alpine \
-        /usr/local/go/bin/go test \
-          ${TEST_EXTRA_ARGS:-} \
-          -v ${testpkgs}
 
 jobs:
   include:
@@ -104,14 +80,6 @@ jobs:
     - <<: *build_sfu_docker_job
       name: Build sfu docker
       if: branch = master OR tag IS present
-    # - <<: *test_i386_job
-    #   name: Test i386 1.13
-    #   env: GO_VERSION=1.13
-    #   go: 1.14 # version for host environment used to go list
-    # - <<: *test_i386_job
-    #   name: Test i386 1.14
-    #   env: GO_VERSION=1.14
-    #   go: 1.14 # version for host environment used to go list
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 GO_LDFLAGS = -ldflags "-s -w"
 GO_VERSION = 1.14
 GO_TESTPKGS:=$(shell go list ./... | grep -v cmd | grep -v examples)
-TEST_UID:=$(shell id -u)
-TEST_GID:=$(shell id -g)
 
 all: nodes
 


### PR DESCRIPTION
updating travis so we can tag releases without pushing `latest` docker tag. since that will break ion