### PR TITLE
fix base64 decode panic; quickly display sdp.

### DIFF
--- a/examples/internal/signal/signal.go
+++ b/examples/internal/signal/signal.go
@@ -60,7 +60,7 @@ func Encode(obj interface{}) string {
 // Decode decodes the input from base64
 // It can optionally unzip the input after decoding
 func Decode(in string, obj interface{}) {
-	b, err := base64.StdEncoding.DecodeString(in)
+	b, err := base64.RawStdEncoding.DecodeString(in)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/pub-from-browser/README.md
+++ b/examples/pub-from-browser/README.md
@@ -8,7 +8,7 @@ go get github.com/pion/ion-sfu/examples/publish-from-browser
 ```
 
 ### Open publish-from-browser example page
-[jsfiddle.net](https://jsfiddle.net/j3yhron4/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/y1b32pom/) you should see two text-areas and a 'Start Session' button.
 
 ### Run publish-from-browser, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/pub-from-browser/README.md
+++ b/examples/pub-from-browser/README.md
@@ -8,7 +8,7 @@ go get github.com/pion/ion-sfu/examples/publish-from-browser
 ```
 
 ### Open publish-from-browser example page
-[jsfiddle.net](https://jsfiddle.net/y1b32pom/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/z01hobnL/) you should see two text-areas and a 'Start Session' button.
 
 ### Run publish-from-browser, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/pub-from-browser/jsfiddle/demo.html
+++ b/examples/pub-from-browser/jsfiddle/demo.html
@@ -8,7 +8,7 @@ Golang base64 Session Description<br />
 <br />
 
 Video<br />
-<div id="remoteVideos"></div>
+<div id="localVideos"></div>
 <br />
 
 Logs<br />

--- a/examples/pub-from-browser/jsfiddle/demo.js
+++ b/examples/pub-from-browser/jsfiddle/demo.js
@@ -27,7 +27,7 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: true })
 
 pc.oniceconnectionstatechange = e => log(pc.iceConnectionState)
 pc.onicecandidate = event => {
-  if (event.candidate === null) {
+  if (event.candidate !== null) {
     document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
   }
 }

--- a/examples/pub-from-browser/jsfiddle/demo.js
+++ b/examples/pub-from-browser/jsfiddle/demo.js
@@ -18,7 +18,8 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: true })
     el.muted = true
     document.getElementById('localVideos').appendChild(el)
 
-    pc.addStream(stream)
+    //pc.addStream(stream)  // deprecated, and safari not supported
+    stream.getTracks().forEach(track => pc.addTrack(track, stream))
     pc.createOffer({
       offerToReceiveVideo: false,
       offerToReceiveAudio: false,
@@ -26,9 +27,18 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   }).catch(log)
 
 pc.oniceconnectionstatechange = e => log(pc.iceConnectionState)
-pc.onicecandidate = event => {
-  if (event.candidate !== null) {
+
+var timer;
+var showSDP = () => {
     document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
+}
+pc.onicecandidate = event => {
+  clearTimeout(timer);
+  if (event.candidate === null) {
+    showSDP()
+  } else {
+    // avoid waiting too long for null, chrome > 30ms, firefox > 10ms
+    timer = setTimeout(showSDP, 1000);
   }
 }
 

--- a/examples/sub-to-browser/README.md
+++ b/examples/sub-to-browser/README.md
@@ -8,7 +8,7 @@ go get github.com/pion/ion-sfu/examples/sub-to-browser
 ```
 
 ### Open sub-to-browser example page
-[jsfiddle.net](https://jsfiddle.net/7kcuxgd5/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/eyncgpqa/) you should see two text-areas and a 'Start Session' button.
 
 ### Run sub-to-browser, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/sub-to-browser/README.md
+++ b/examples/sub-to-browser/README.md
@@ -8,7 +8,7 @@ go get github.com/pion/ion-sfu/examples/sub-to-browser
 ```
 
 ### Open sub-to-browser example page
-[jsfiddle.net](https://jsfiddle.net/04r7xbLa/) you should see two text-areas and a 'Start Session' button.
+[jsfiddle.net](https://jsfiddle.net/7kcuxgd5/) you should see two text-areas and a 'Start Session' button.
 
 ### Run sub-to-browser, with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/examples/sub-to-browser/jsfiddle/demo.js
+++ b/examples/sub-to-browser/jsfiddle/demo.js
@@ -15,11 +15,21 @@ pc.addTransceiver("video", { direction: 'recvonly' });
 pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
 
 pc.oniceconnectionstatechange = e => log(pc.iceConnectionState)
-pc.onicecandidate = event => {
-  if (event.candidate !== null) {
+
+var timer;
+var showSDP = () => {
     document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
+}
+pc.onicecandidate = event => {
+  clearTimeout(timer);
+  if (event.candidate === null) {
+    showSDP()
+  } else {
+    // avoid waiting too long for null, chrome > 30ms, firefox > 10ms
+    timer = setTimeout(showSDP, 1000);
   }
 }
+
 pc.ontrack = function (event) {
 	if (event.track.kind === "video") {
     var el = document.createElement(event.track.kind)

--- a/examples/sub-to-browser/jsfiddle/demo.js
+++ b/examples/sub-to-browser/jsfiddle/demo.js
@@ -16,7 +16,7 @@ pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
 
 pc.oniceconnectionstatechange = e => log(pc.iceConnectionState)
 pc.onicecandidate = event => {
-  if (event.candidate === null) {
+  if (event.candidate !== null) {
     document.getElementById('localSessionDescription').value = btoa(JSON.stringify(pc.localDescription))
   }
 }


### PR DESCRIPTION
fix base64 decode panic: illegal base64 data at input byte xxx.
quickly display sdp in chrome/firefox.