### PR TITLE
enhancement/new-transport-media-engine

### DIFF
--- a/cmd/server/grpc/main.go
+++ b/cmd/server/grpc/main.go
@@ -184,7 +184,14 @@ func (s *server) Signal(stream pb.SFU_SignalServer) error {
 				SDP:  string(payload.Join.Offer.Sdp),
 			}
 
-			peer, err = s.sfu.NewWebRTCTransport(payload.Join.Sid, offer)
+			me := sfu.MediaEngine{}
+			err := me.PopulateFromSDP(offer)
+			if err != nil {
+				log.Errorf("join error: %v", err)
+				return status.Errorf(codes.InvalidArgument, "join error %s", err)
+			}
+
+			peer, err = s.sfu.NewWebRTCTransport(payload.Join.Sid, me)
 			if err != nil {
 				log.Errorf("join error: %v", err)
 				return status.Errorf(codes.InvalidArgument, "join error %s", err)
@@ -198,7 +205,7 @@ func (s *server) Signal(stream pb.SFU_SignalServer) error {
 				return status.Errorf(codes.Internal, "join error %s", err)
 			}
 
-			answer, err := peer.CreateAnswer()
+			answer, err = peer.CreateAnswer()
 			if err != nil {
 				log.Errorf("join error: %v", err)
 				return status.Errorf(codes.Internal, "join error %s", err)

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -3,7 +3,6 @@ package sfu
 import "errors"
 
 var (
-	errSdpParseFailed           = errors.New("sdp parse failed")
 	errPeerConnectionInitFailed = errors.New("pc init failed")
 	errChanClosed               = errors.New("channel closed")
 	errPtNotSupported           = errors.New("payload type not supported")

--- a/pkg/session_test.go
+++ b/pkg/session_test.go
@@ -418,7 +418,7 @@ func Test3PeerStaggerJoin(t *testing.T) {
 	assert.NoError(t, err)
 	offer, err = remoteC.CreateOffer(nil)
 	assert.NoError(t, err)
-	err = remoteB.SetLocalDescription(offer)
+	err = remoteC.SetLocalDescription(offer)
 	assert.NoError(t, err)
 	gatherComplete = webrtc.GatheringCompletePromise(remoteC)
 	engine = MediaEngine{}

--- a/pkg/sfu.go
+++ b/pkg/sfu.go
@@ -115,14 +115,14 @@ func (s *SFU) getSession(id string) *Session {
 }
 
 // NewWebRTCTransport creates a new WebRTCTransport that is a member of a session
-func (s *SFU) NewWebRTCTransport(sid string, offer webrtc.SessionDescription) (*WebRTCTransport, error) {
+func (s *SFU) NewWebRTCTransport(sid string, me MediaEngine) (*WebRTCTransport, error) {
 	session := s.getSession(sid)
 
 	if session == nil {
 		session = s.newSession(sid)
 	}
 
-	t, err := NewWebRTCTransport(session, offer, s.webrtc)
+	t, err := NewWebRTCTransport(session, me, s.webrtc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sfu_test.go
+++ b/pkg/sfu_test.go
@@ -30,7 +30,11 @@ func TestSFU(t *testing.T) {
 	err = remote.SetLocalDescription(offer)
 	assert.NoError(t, err)
 
-	transport, err := s.NewWebRTCTransport("test session", offer)
+	engine := MediaEngine{}
+	err = engine.PopulateFromSDP(offer)
+	assert.NoError(t, err)
+
+	transport, err := s.NewWebRTCTransport("test session", engine)
 	assert.NotNil(t, transport)
 	assert.NoError(t, err)
 }

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -34,14 +34,7 @@ type WebRTCTransport struct {
 }
 
 // NewWebRTCTransport creates a new WebRTCTransport
-func NewWebRTCTransport(session *Session, offer webrtc.SessionDescription, cfg WebRTCTransportConfig) (*WebRTCTransport, error) {
-	// We make our own mediaEngine so we can place the sender's codecs in it.  This because we must use the
-	// dynamic media type from the sender in our answer. This is not required if we are the offerer
-	me := MediaEngine{}
-	if err := me.PopulateFromSDP(offer); err != nil {
-		return nil, errSdpParseFailed
-	}
-
+func NewWebRTCTransport(session *Session, me MediaEngine, cfg WebRTCTransportConfig) (*WebRTCTransport, error) {
 	api := webrtc.NewAPI(webrtc.WithMediaEngine(me.MediaEngine), webrtc.WithSettingEngine(cfg.setting))
 	pc, err := api.NewPeerConnection(cfg.configuration)
 

--- a/pkg/webrtctransport_test.go
+++ b/pkg/webrtctransport_test.go
@@ -43,7 +43,13 @@ func signalPeer(session *Session, remote *webrtc.PeerConnection) (*WebRTCTranspo
 	}
 	gatherComplete := webrtc.GatheringCompletePromise(remote)
 
-	peer, err := NewWebRTCTransport(session, offer, conf)
+	engine := MediaEngine{}
+	err = engine.PopulateFromSDP(offer)
+	if err != nil {
+		return nil, err
+	}
+
+	peer, err := NewWebRTCTransport(session, engine, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +169,11 @@ func TestPeerPairRemoteBGetsOnTrack(t *testing.T) {
 	assert.NoError(t, err)
 	gatherComplete := webrtc.GatheringCompletePromise(remoteB)
 
-	peerB, err := NewWebRTCTransport(session, offer, conf)
+	engine := MediaEngine{}
+	err = engine.PopulateFromSDP(offer)
+	assert.NoError(t, err)
+
+	peerB, err := NewWebRTCTransport(session, engine, conf)
 	assert.NoError(t, err)
 
 	// Subscribe to remoteA track
@@ -312,7 +322,11 @@ func TestEventHandlers(t *testing.T) {
 	assert.NoError(t, err)
 	gatherComplete := webrtc.GatheringCompletePromise(remoteB)
 
-	peerB, err := NewWebRTCTransport(session, offer, conf)
+	engine := MediaEngine{}
+	err = engine.PopulateFromSDP(offer)
+	assert.NoError(t, err)
+
+	peerB, err := NewWebRTCTransport(session, engine, conf)
 	assert.NoError(t, err)
 
 	// Subscribe to remoteA track


### PR DESCRIPTION
#### Description

Changes the `NewWebRTCTransport` function to use the `MediaEngine` rather than an `SessionDescription`, this enables the SFU to make offers.