### PR TITLE
feat: improve rembLoop() coverage by 2%

### DIFF
--- a/pkg/session_test.go
+++ b/pkg/session_test.go
@@ -28,7 +28,7 @@ func createPeer(t *testing.T, session *Session, api *webrtc.API) (*WebRTCTranspo
 	}
 
 	// Setup remote <-> peer for a
-	peer, err := signalPeer(session, remote)
+	peer, err := signalPeer(session, remote, config.Receiver.Video)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -72,7 +72,7 @@ func TestSession(t *testing.T) {
 	err = engine.PopulateFromSDP(*remote.LocalDescription())
 	assert.NoError(t, err)
 
-	peer, err := NewWebRTCTransport(session, engine, conf)
+	peer, err := NewWebRTCTransport(session, engine, conf, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onCloseFired, onCloseFiredFunc := context.WithCancel(context.Background())
@@ -113,7 +113,7 @@ func TestMultiPeerSession(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, WebRTCVideoReceiverConfig{REMBCycle: 1})
 	assert.NoError(t, err)
 
 	// Add a pub track for remote B
@@ -123,7 +123,7 @@ func TestMultiPeerSession(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setup remote <-> peer for b
-	peerB, err := signalPeer(session, remoteB)
+	peerB, err := signalPeer(session, remoteB, WebRTCVideoReceiverConfig{REMBCycle: 2})
 	assert.NoError(t, err)
 
 	onReadRTPFired, onReadRTPFiredFunc := context.WithCancel(context.Background())
@@ -345,7 +345,7 @@ func Test3PeerStaggerJoin(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, WebRTCVideoReceiverConfig{REMBCycle: 1})
 	assert.NoError(t, err)
 
 	session.AddTransport(peerA)
@@ -368,7 +368,7 @@ func Test3PeerStaggerJoin(t *testing.T) {
 	err = engine.PopulateFromSDP(offer)
 	assert.NoError(t, err)
 	gatherComplete := webrtc.GatheringCompletePromise(remoteB)
-	peerB, err := NewWebRTCTransport(session, engine, conf)
+	peerB, err := NewWebRTCTransport(session, engine, conf, config.Receiver.Video)
 	session.AddTransport(peerB)
 	assert.NoError(t, err)
 	<-gatherComplete
@@ -424,7 +424,7 @@ func Test3PeerStaggerJoin(t *testing.T) {
 	engine = MediaEngine{}
 	err = engine.PopulateFromSDP(offer)
 	assert.NoError(t, err)
-	peerC, err := NewWebRTCTransport(session, engine, conf)
+	peerC, err := NewWebRTCTransport(session, engine, conf, config.Receiver.Video)
 	session.AddTransport(peerC)
 	assert.NoError(t, err)
 	<-gatherComplete
@@ -483,7 +483,7 @@ func TestPeerBWithAudioAndVideoWhenPeerAHasAudioOnly(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackAAudio := waitForRouter(peerA, trackAAudio.SSRC())
@@ -510,7 +510,7 @@ func TestPeerBWithAudioAndVideoWhenPeerAHasAudioOnly(t *testing.T) {
 	_, err = remoteB.AddTrack(trackBVideo)
 	assert.NoError(t, err)
 
-	peerB, err := signalPeer(session, remoteB)
+	peerB, err := signalPeer(session, remoteB, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackBAudio := waitForRouter(peerB, trackBAudio.SSRC())

--- a/pkg/sfu.go
+++ b/pkg/sfu.go
@@ -124,7 +124,7 @@ func (s *SFU) NewWebRTCTransport(sid string, me MediaEngine) (*WebRTCTransport, 
 		session = s.newSession(sid)
 	}
 
-	t, err := NewWebRTCTransport(session, me, s.webrtc)
+	t, err := NewWebRTCTransport(session, me, s.webrtc, config.Receiver.Video)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -34,7 +34,7 @@ type WebRTCTransport struct {
 }
 
 // NewWebRTCTransport creates a new WebRTCTransport
-func NewWebRTCTransport(session *Session, me MediaEngine, cfg WebRTCTransportConfig) (*WebRTCTransport, error) {
+func NewWebRTCTransport(session *Session, me MediaEngine, cfg WebRTCTransportConfig, rcfg WebRTCVideoReceiverConfig) (*WebRTCTransport, error) {
 	api := webrtc.NewAPI(webrtc.WithMediaEngine(me.MediaEngine), webrtc.WithSettingEngine(cfg.setting))
 	pc, err := api.NewPeerConnection(cfg.configuration)
 
@@ -72,7 +72,7 @@ func NewWebRTCTransport(session *Session, me MediaEngine, cfg WebRTCTransportCon
 		var recv Receiver
 		switch track.Kind() {
 		case webrtc.RTPCodecTypeVideo:
-			recv = NewWebRTCVideoReceiver(config.Receiver.Video, track)
+			recv = NewWebRTCVideoReceiver(rcfg, track)
 		case webrtc.RTPCodecTypeAudio:
 			recv = NewWebRTCAudioReceiver(track)
 		}

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -166,6 +166,11 @@ func (p *WebRTCTransport) SetRemoteDescription(desc webrtc.SessionDescription) e
 	return nil
 }
 
+// LocalDescription returns the peer connection LocalDescription
+func (p *WebRTCTransport) LocalDescription() *webrtc.SessionDescription {
+	return p.pc.LocalDescription()
+}
+
 // AddICECandidate to peer connection
 func (p *WebRTCTransport) AddICECandidate(candidate webrtc.ICECandidateInit) error {
 	return p.pc.AddICECandidate(candidate)

--- a/pkg/webrtctransport_test.go
+++ b/pkg/webrtctransport_test.go
@@ -33,7 +33,7 @@ func newPair(cfg webrtc.Configuration, api *webrtc.API) (pcOffer *webrtc.PeerCon
 	return pca, pcb, nil
 }
 
-func signalPeer(session *Session, remote *webrtc.PeerConnection) (*WebRTCTransport, error) {
+func signalPeer(session *Session, remote *webrtc.PeerConnection, rcfg WebRTCVideoReceiverConfig) (*WebRTCTransport, error) {
 	offer, err := remote.CreateOffer(nil)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func signalPeer(session *Session, remote *webrtc.PeerConnection) (*WebRTCTranspo
 		return nil, err
 	}
 
-	peer, err := NewWebRTCTransport(session, engine, conf)
+	peer, err := NewWebRTCTransport(session, engine, conf, rcfg)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func TestNewPeerCallsOnRouterWithVideoTrackRouter(t *testing.T) {
 
 	// Create sfu peer for remote A and complete signaling
 	session := NewSession("session")
-	peer, err := signalPeer(session, remote)
+	peer, err := signalPeer(session, remote, config.Receiver.Video)
 	assert.NoError(t, err)
 	assert.Equal(t, peer.id, peer.ID())
 
@@ -154,7 +154,7 @@ func TestNewPeerCallsOnRouterWithAudioTrackRouter(t *testing.T) {
 
 	// Create sfu peer for remote A and complete signaling
 	session := NewSession("session")
-	peer, err := signalPeer(session, remote)
+	peer, err := signalPeer(session, remote, config.Receiver.Video)
 	assert.NoError(t, err)
 	assert.Equal(t, peer.id, peer.ID())
 
@@ -178,7 +178,7 @@ func TestPeerPairRemoteBGetsOnTrack(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	// Add a pub track for remote B
@@ -202,7 +202,7 @@ func TestPeerPairRemoteBGetsOnTrack(t *testing.T) {
 	err = engine.PopulateFromSDP(offer)
 	assert.NoError(t, err)
 
-	peerB, err := NewWebRTCTransport(session, engine, conf)
+	peerB, err := NewWebRTCTransport(session, engine, conf, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	// Subscribe to remoteA track
@@ -244,7 +244,7 @@ func TestPeerPairRemoteAGetsOnTrackWhenRemoteBJoinsWithPub(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackA := waitForRouter(peerA, trackA.SSRC())
@@ -262,7 +262,7 @@ func TestPeerPairRemoteAGetsOnTrackWhenRemoteBJoinsWithPub(t *testing.T) {
 	})
 
 	// Setup remote <-> peer for a
-	peerB, err := signalPeer(session, remoteB)
+	peerB, err := signalPeer(session, remoteB, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackB := waitForRouter(peerB, trackB.SSRC())
@@ -315,7 +315,7 @@ func TestEventHandlers(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	peerAOnTrackFired, peerAOnTrackFiredFunc := context.WithCancel(context.Background())
@@ -355,7 +355,7 @@ func TestEventHandlers(t *testing.T) {
 	err = engine.PopulateFromSDP(offer)
 	assert.NoError(t, err)
 
-	peerB, err := NewWebRTCTransport(session, engine, conf)
+	peerB, err := NewWebRTCTransport(session, engine, conf, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	// Subscribe to remoteA track
@@ -407,7 +407,7 @@ func TestPeerBWithAudioOnlyWhenPeerAHasAudioAndVideo(t *testing.T) {
 	session := NewSession("session")
 
 	// Setup remote <-> peer for a
-	peerA, err := signalPeer(session, remoteA)
+	peerA, err := signalPeer(session, remoteA, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackAAudio := waitForRouter(peerA, trackAAudio.SSRC())
@@ -430,7 +430,7 @@ func TestPeerBWithAudioOnlyWhenPeerAHasAudioAndVideo(t *testing.T) {
 	_, err = remoteB.AddTrack(trackBAudio)
 	assert.NoError(t, err)
 
-	peerB, err := signalPeer(session, remoteB)
+	peerB, err := signalPeer(session, remoteB, config.Receiver.Video)
 	assert.NoError(t, err)
 
 	onTrackBAudio := waitForRouter(peerB, trackBAudio.SSRC())
@@ -468,7 +468,7 @@ func TestPeerRemovesRouterWhenRemoteRemovesTrack(t *testing.T) {
 
 	// Create sfu peer for remote A and complete signaling
 	session := NewSession("session")
-	peer, err := signalPeer(session, remote)
+	peer, err := signalPeer(session, remote, config.Receiver.Video)
 	assert.NoError(t, err)
 	assert.Equal(t, peer.id, peer.ID())
 


### PR DESCRIPTION
#### Description
This PR is intended to improve code coverage for rtcp feedback (remb, nack, ect.) and jitter buffer + error cases generally

- [x] Added dependency injection to `NewWebRTCTransport`  with `WebRTCVideoReceiverConfig` to ease writing tests for receiver





#### Reference issue
Fixes #59
