### PR TITLE
Doc and example bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ go build ./cmd/server/json-rpc/main.go && ./main -c config.toml
 If you prefer a containerized environment, you can use the included Docker image
 
 ```
-docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pion/ion-sfu:v1.0.5-json-rpc
+docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pionwebrtc/ion-sfu:v1.0.6-jsonrpc
 ```
 
 ### Running the grpc server
@@ -43,7 +43,7 @@ go build ./cmd/server/grpc/main.go && ./main -c config.toml
 If you prefer a containerized environment, you can use the included Docker image
 
 ```
-docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pion/ion-sfu:v1.0.5-grpc
+docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pionwebrtc/ion-sfu:v1.0.6-grpc
 ```
 
 ### Interacting with the server

--- a/examples/pub-from-browser/jsfiddle/demo.js
+++ b/examples/pub-from-browser/jsfiddle/demo.js
@@ -16,7 +16,7 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: true })
     el.autoplay = true
     el.controls = true
     el.muted = true
-    document.getElementById('localVideos').appendChild(el)
+    document.getElementById('remoteVideos').appendChild(el)
 
     pc.addStream(stream)
     pc.createOffer({


### PR DESCRIPTION
#### Description
This pull request addresses the following issues:

- The docker commands in the `README.md` file reference the wrong Dockerhub user `pion` instead of `pionwebrtc`. Therefore when you try to pull the image, you get the following error message: `docker: Error response from daemon: pull access denied for pion/ion-sfu, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.`.
- Typo in the `pub-from-browser` where the wrong name is used to reference the div. As a result the application throws an error when clicking on the `Start session` button.