### PR TITLE
Check for context done on Sender.receiveRTCP close #141

### DIFF
--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -134,7 +134,7 @@ func (s *WebRTCSender) Close() {
 func (s *WebRTCSender) receiveRTCP() {
 	for {
 		pkts, err := s.sender.ReadRTCP()
-		if err == io.ErrClosedPipe || err == io.EOF {
+		if err == io.ErrClosedPipe || err == io.EOF || s.ctx.Err() != nil {
 			return
 		}
 


### PR DESCRIPTION
#### Description
Check for context done, to prevent writing on closed channel.

#### Reference issue
Fixes #141 
