### PR TITLE
chore(ctx): safe context done on channel writers

### DIFF
--- a/pkg/receiver.go
+++ b/pkg/receiver.go
@@ -168,9 +168,6 @@ func (v *WebRTCVideoReceiver) ReadRTP() (*rtp.Packet, error) {
 	case pkt := <-v.rtpCh:
 		return pkt, nil
 	case <-v.ctx.Done():
-		v.mu.Lock()
-		defer v.mu.Unlock()
-		close(v.rtpCh)
 		return nil, io.EOF
 	}
 }
@@ -181,9 +178,6 @@ func (v *WebRTCVideoReceiver) ReadRTCP() (rtcp.Packet, error) {
 	case pkt := <-v.rtcpCh:
 		return pkt, nil
 	case <-v.ctx.Done():
-		v.mu.Lock()
-		defer v.mu.Unlock()
-		close(v.rtcpCh)
 		return nil, io.ErrClosedPipe
 	}
 }
@@ -331,14 +325,14 @@ func (v *WebRTCVideoReceiver) tccLoop(cycle int) {
 	for {
 		select {
 		case <-t.C:
-			cap := len(v.rtpExtInfoChan)
-			if cap == 0 {
+			cp := len(v.rtpExtInfoChan)
+			if cp == 0 {
 				continue
 			}
 
 			// get all rtp extension infos from channel
 			rtpExtInfo := make(map[uint16]int64)
-			for i := 0; i < cap; i++ {
+			for i := 0; i < cp; i++ {
 				info := <-v.rtpExtInfoChan
 				rtpExtInfo[info.TSN] = info.Timestamp
 			}

--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -82,9 +82,6 @@ func (s *WebRTCSender) sendRTP() {
 				log.Errorf("wt.WriteRTP err=%v", err)
 			}
 		case <-s.ctx.Done():
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			close(s.sendChan)
 			return
 		}
 	}
@@ -96,7 +93,6 @@ func (s *WebRTCSender) ReadRTCP() (rtcp.Packet, error) {
 	case pkt := <-s.rtcpCh:
 		return pkt, nil
 	case <-s.ctx.Done():
-		close(s.rtcpCh)
 		err := s.sender.Stop()
 		if err != nil {
 			return nil, err
@@ -207,7 +203,6 @@ func (s *WebRTCSender) rembLoop() {
 				lowest = math.MaxUint64
 			}
 		case <-s.ctx.Done():
-			close(s.rembCh)
 			return
 		}
 	}


### PR DESCRIPTION
#### Description

Since select statements can proceed in a pseudo-random selection, it's possible that runtime choose another case even if ctx.Done is called.

It's good practice to double check for context done that are in select, to prevent writing on closed channels.
