### PR TITLE
Update  pub-sub-in-browser example readme

### DIFF
--- a/examples/pub-sub-in-browser/README.md
+++ b/examples/pub-sub-in-browser/README.md
@@ -4,7 +4,7 @@ Demonstrates how to publish video and/or audio to an `ion-sfu` from the browser 
 ## Instructions
 ```
 go build cmd/server/json-rpc/main.go
-./main -c config.toml -p 7000
+./main -c config.toml
 ```
 ### Open pub-sub-in-browser fiddle
 Open fiddle [here](https://jsfiddle.net/8gcrvojw/) you should be prompted to allow media access. Once you accept, you will see your local video. First, click "Publish" to publish it. Once it is published, open another fiddle instance and click publish. Each fiddle will receive the others stream and display it under remote streams.


### PR DESCRIPTION
#### Description

The command line flag `-p` has been changed to `-a`. The current startup command in the readme will lead to an error indicating that the flag is not valid.
