### PR TITLE
fix(sender): write on closed pipe err

### DIFF
--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -85,7 +85,10 @@ func (s *WebRTCSender) sendRTP() {
 			pkt = &newPkt
 
 			if err := s.track.WriteRTP(pkt); err != nil {
-				log.Errorf("wt.WriteRTP err=%v", err)
+				if err == io.ErrClosedPipe {
+					return
+				}
+				log.Errorf("sender.track.WriteRTP err=%v", err)
 			}
 		case <-s.ctx.Done():
 			return


### PR DESCRIPTION
Handle `io.ErrClosedPipe` more gracefully.

We should simplify how we are closing senders. It should be triggered by the `p.pc.RemoveTrack` call, rather than the other way around.