### PR TITLE
feat(receivers): refactor receivers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ maxbandwidth = 1000
 # zero means no rate limit
 maxnacktime = 1
 
-[receiver.video]
+[router.video]
 # the remb cycle sending to pub, this told the pub it's bandwidth
 rembcycle = 2
 # pli cycle sending to pub, and pub will send a key frame

--- a/pkg/buffer.go
+++ b/pkg/buffer.go
@@ -267,5 +267,7 @@ func (b *Buffer) GetLostRateBandwidth(cycle uint64) (float64, uint64) {
 
 // GetPacket get packet by sequence number
 func (b *Buffer) GetPacket(sn uint16) *rtp.Packet {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.pktBuffer[sn]
 }

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -5,5 +5,4 @@ import "errors"
 var (
 	errPeerConnectionInitFailed = errors.New("pc init failed")
 	errPtNotSupported           = errors.New("payload type not supported")
-	errMethodNotSupported       = errors.New("method not supported")
 )

--- a/pkg/router_test.go
+++ b/pkg/router_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pion/transport/test"
 	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +33,7 @@ func TestRouter(t *testing.T) {
 	done := make(chan bool)
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
-		receiver := NewWebRTCVideoReceiver(ctx, WebRTCVideoReceiverConfig{}, track)
+		receiver := NewWebRTCReceiver(ctx, track).(*WebRTCReceiver)
 		router := NewRouter("id", receiver)
 		assert.Equal(t, router.receiver, receiver)
 
@@ -68,10 +69,8 @@ func TestRouter(t *testing.T) {
 		<-ontrackFired
 
 		sub.Close()
-		router.close()
-		router.mu.RLock()
-		assert.Len(t, router.senders, 0)
-		router.mu.RUnlock()
+		receiver.Close()
+		sender.Close()
 		<-sender.ctx.Done()
 		<-receiver.ctx.Done()
 		close(done)
@@ -108,7 +107,7 @@ func TestRouterPartialReadCanClose(t *testing.T) {
 	subClosed := make(chan bool)
 	onTrackFired, onTrackFiredFunc := context.WithCancel(context.Background())
 	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
-		receiver := NewWebRTCVideoReceiver(ctx, WebRTCVideoReceiverConfig{}, track)
+		receiver := NewWebRTCReceiver(ctx, track).(*WebRTCReceiver)
 		router := NewRouter("id", receiver)
 		subsfu, sub, err := newPair(webrtc.Configuration{}, api)
 		assert.NoError(t, err)
@@ -172,7 +171,7 @@ func TestSendersNackRateLimit(t *testing.T) {
 	ctx := context.Background()
 	done := make(chan bool)
 	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
-		receiver := NewWebRTCVideoReceiver(ctx, WebRTCVideoReceiverConfig{}, track)
+		receiver := NewWebRTCReceiver(ctx, track).(*WebRTCReceiver)
 		router := NewRouter("id", receiver)
 		assert.Equal(t, router.receiver, receiver)
 
@@ -245,6 +244,104 @@ func TestSendersNackRateLimit(t *testing.T) {
 	assert.NoError(t, err)
 
 	sendRTPUntilDone(onTimeout.Done(), t, []*webrtc.Track{track})
+	<-done
+
+	pubsfu.Close()
+	pub.Close()
+}
+
+func TestReceiverCloseOnTrackRemoved(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	me := webrtc.MediaEngine{}
+	me.RegisterDefaultCodecs()
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(me))
+	pubsfu, pub, err := newPair(webrtc.Configuration{}, api)
+	assert.NoError(t, err)
+
+	onTimeout, onTimeoutFunc := context.WithCancel(context.Background())
+	track, err := pub.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion")
+	assert.NoError(t, err)
+	subsfu, sub, err := newPair(webrtc.Configuration{}, api)
+	assert.NoError(t, err)
+
+	pubSender, err := pub.AddTrack(track)
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	done := make(chan bool)
+
+	onNegotiationFired := make(chan struct{})
+
+	subsfu.OnNegotiationNeeded(func() {
+		println("negotiation required")
+		time.Sleep(5 * time.Second)
+		err = signalPair(subsfu, sub)
+		assert.NoError(t, err)
+		onNegotiationFired <- struct{}{}
+		onTimeoutFunc()
+	})
+
+	pubsfu.OnNegotiationNeeded(func() {
+		println("negotiation required pub")
+	})
+
+	pubsfu.OnTrack(func(track *webrtc.Track, _ *webrtc.RTPReceiver) {
+		receiver := NewWebRTCReceiver(ctx, track).(*WebRTCReceiver)
+		router := NewRouter("id", receiver)
+		assert.Equal(t, router.receiver, receiver)
+
+		sub.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
+			out, err := track.ReadRTP()
+			assert.NoError(t, err)
+			assert.Equal(t, []byte{0x10, 0x01, 0x02, 0x03, 0x04}, out.Payload)
+			// Publisher removes his track
+			err = pub.RemoveTrack(pubSender)
+			assert.NoError(t, err)
+		})
+
+		subtrack, err := subsfu.NewTrack(webrtc.DefaultPayloadTypeVP8, track.SSRC(), "video", "pion")
+		assert.NoError(t, err)
+
+		s, err := subsfu.AddTrack(subtrack)
+		assert.NoError(t, err)
+
+		err = signalPair(subsfu, sub)
+		assert.NoError(t, err)
+
+		subPid := "subpid"
+		sender := NewWebRTCSender(ctx, subtrack, s)
+		router.AddSender(subPid, sender)
+		assert.Len(t, router.senders, 1)
+		assert.Equal(t, sender, router.senders[subPid])
+		assert.Contains(t, router.stats(), "track id:")
+		<-onNegotiationFired
+		router.mu.RLock()
+		assert.Len(t, router.senders, 0)
+		router.mu.RUnlock()
+		sub.Close()
+		<-sender.ctx.Done()
+		<-receiver.ctx.Done()
+		close(done)
+
+		subsfu.Close()
+	})
+
+	err = signalPair(pub, pubsfu)
+	assert.NoError(t, err)
+
+	for {
+		select {
+		case <-onTimeout.Done():
+			break
+		default:
+			err := track.WriteSample(media.Sample{Data: []byte{0x01, 0x02, 0x03, 0x04}, Samples: 1})
+			if err != nil {
+				println(err)
+			}
+		}
+	}
 	<-done
 
 	pubsfu.Close()

--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/pion/ion-sfu/pkg/log"
@@ -32,6 +33,8 @@ type WebRTCSender struct {
 	maxBitrate     uint64
 	target         uint64
 	sendChan       chan *rtp.Packet
+
+	once sync.Once
 }
 
 // NewWebRTCSender creates a new track sender instance
@@ -100,6 +103,10 @@ func (s *WebRTCSender) OnClose(f func()) {
 
 // Close track
 func (s *WebRTCSender) Close() {
+	s.once.Do(s.close)
+}
+
+func (s *WebRTCSender) close() {
 	s.cancel()
 	if s.onCloseHandler != nil {
 		s.onCloseHandler()

--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"time"
 
 	"github.com/pion/ion-sfu/pkg/log"
@@ -15,10 +14,11 @@ import (
 
 // Sender defines a interface for a track receiver
 type Sender interface {
-	ReadRTCP() (rtcp.Packet, error)
+	ReadRTCP() chan rtcp.Packet
 	WriteRTP(*rtp.Packet)
-	stats() string
 	Close()
+	OnCloseHandler(fn func())
+	stats() string
 }
 
 // WebRTCSender represents a Sender which writes RTP to a webrtc track
@@ -29,14 +29,13 @@ type WebRTCSender struct {
 	sender         *webrtc.RTPSender
 	track          *webrtc.Track
 	rtcpCh         chan rtcp.Packet
-	rembCh         chan *rtcp.ReceiverEstimatedMaximumBitrate
 	maxBitrate     uint64
 	target         uint64
 	sendChan       chan *rtp.Packet
 }
 
 // NewWebRTCSender creates a new track sender instance
-func NewWebRTCSender(ctx context.Context, track *webrtc.Track, sender *webrtc.RTPSender) *WebRTCSender {
+func NewWebRTCSender(ctx context.Context, track *webrtc.Track, sender *webrtc.RTPSender) Sender {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &WebRTCSender{
 		ctx:        ctx,
@@ -46,20 +45,6 @@ func NewWebRTCSender(ctx context.Context, track *webrtc.Track, sender *webrtc.RT
 		maxBitrate: routerConfig.MaxBandwidth * 1000,
 		rtcpCh:     make(chan rtcp.Packet, maxSize),
 		sendChan:   make(chan *rtp.Packet, maxSize),
-	}
-
-	for _, feedback := range track.Codec().RTCPFeedback {
-		switch feedback.Type {
-		case webrtc.TypeRTCPFBGoogREMB:
-			if routerConfig.REMBFeedback {
-				log.Debugf("Using sender feedback %s", webrtc.TypeRTCPFBGoogREMB)
-				s.rembCh = make(chan *rtcp.ReceiverEstimatedMaximumBitrate, maxSize)
-				go s.rembLoop()
-			}
-		case webrtc.TypeRTCPFBTransportCC:
-			log.Debugf("Using sender feedback %s", webrtc.TypeRTCPFBTransportCC)
-			// TODO
-		}
 	}
 
 	go s.receiveRTCP()
@@ -97,25 +82,13 @@ func (s *WebRTCSender) sendRTP() {
 }
 
 // ReadRTCP read rtp packet
-func (s *WebRTCSender) ReadRTCP() (rtcp.Packet, error) {
-	select {
-	case pkt := <-s.rtcpCh:
-		return pkt, nil
-	case <-s.ctx.Done():
-		err := s.sender.Stop()
-		if err != nil {
-			return nil, err
-		}
-		return nil, io.ErrClosedPipe
-	}
+func (s *WebRTCSender) ReadRTCP() chan rtcp.Packet {
+	return s.rtcpCh
 }
 
 // WriteRTP to the track
 func (s *WebRTCSender) WriteRTP(pkt *rtp.Packet) {
-	select {
-	case <-s.ctx.Done():
-		return
-	default:
+	if s.ctx.Err() == nil {
 		s.sendChan <- pkt
 	}
 }
@@ -128,16 +101,22 @@ func (s *WebRTCSender) OnClose(f func()) {
 // Close track
 func (s *WebRTCSender) Close() {
 	s.cancel()
-
 	if s.onCloseHandler != nil {
 		s.onCloseHandler()
 	}
 }
 
+// OnCloseHandler method to be called on remote tracked removed
+func (s *WebRTCSender) OnCloseHandler(fn func()) {
+	s.onCloseHandler = fn
+}
+
 func (s *WebRTCSender) receiveRTCP() {
 	for {
 		pkts, err := s.sender.ReadRTCP()
-		if err == io.ErrClosedPipe || err == io.EOF || s.ctx.Err() != nil {
+		if err == io.ErrClosedPipe || s.ctx.Err() != nil {
+			close(s.rtcpCh)
+			s.Close()
 			return
 		}
 
@@ -149,64 +128,9 @@ func (s *WebRTCSender) receiveRTCP() {
 			switch pkt := pkt.(type) {
 			case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest, *rtcp.TransportLayerNack:
 				s.rtcpCh <- pkt
-			case *rtcp.ReceiverEstimatedMaximumBitrate:
-				if s.rembCh != nil {
-					s.rembCh <- pkt
-				}
+			default:
+				// TODO: Use fb packets for congestion control
 			}
-		}
-	}
-}
-
-func (s *WebRTCSender) rembLoop() {
-	lastRembTime := time.Now()
-	maxRembTime := 200 * time.Millisecond
-	rembMin := uint64(100000)
-	if rembMin == 0 {
-		rembMin = 10000 // 10 KBit
-	}
-	var lowest uint64 = math.MaxUint64
-	var rembCount, rembTotalRate uint64
-
-	for {
-		select {
-		case pkt := <-s.rembCh:
-			// Update stats
-			rembCount++
-			rembTotalRate += pkt.Bitrate
-			if pkt.Bitrate < lowest {
-				lowest = pkt.Bitrate
-			}
-
-			// Send upstream if time
-			if time.Since(lastRembTime) > maxRembTime {
-				lastRembTime = time.Now()
-				avg := uint64(rembTotalRate / rembCount)
-
-				_ = avg
-				s.target = lowest
-
-				if s.target < rembMin {
-					s.target = rembMin
-				} else if s.target > s.maxBitrate && s.maxBitrate > 0 {
-					s.target = s.maxBitrate
-				}
-
-				newPkt := &rtcp.ReceiverEstimatedMaximumBitrate{
-					Bitrate:    s.target,
-					SenderSSRC: 1,
-					SSRCs:      pkt.SSRCs,
-				}
-
-				s.rtcpCh <- newPkt
-
-				// Reset stats
-				rembCount = 0
-				rembTotalRate = 0
-				lowest = math.MaxUint64
-			}
-		case <-s.ctx.Done():
-			return
 		}
 	}
 }

--- a/pkg/session_test.go
+++ b/pkg/session_test.go
@@ -171,9 +171,6 @@ func TestMultiPeerSession(t *testing.T) {
 
 	assert.NoError(t, peerA.Close())
 	router = peerB.GetRouter(trackB.SSRC())
-	router.mu.RLock()
-	assert.Len(t, router.senders, 0)
-	router.mu.RUnlock()
 
 	assert.NoError(t, peerB.Close())
 	<-onNegotationNeededFired.Done()

--- a/pkg/sfu.go
+++ b/pkg/sfu.go
@@ -25,24 +25,19 @@ type WebRTCConfig struct {
 	ICEServers   []ICEServerConfig `mapstructure:"iceserver"`
 }
 
-// ReceiverConfig defines receiver configurations
-type ReceiverConfig struct {
-	Video WebRTCVideoReceiverConfig `mapstructure:"video"`
-}
-
 // Config for base SFU
 type Config struct {
-	WebRTC   WebRTCConfig   `mapstructure:"webrtc"`
-	Log      log.Config     `mapstructure:"log"`
-	Receiver ReceiverConfig `mapstructure:"receiver"`
-	Router   RouterConfig   `mapstructure:"router"`
+	WebRTC WebRTCConfig `mapstructure:"webrtc"`
+	Log    log.Config   `mapstructure:"log"`
+	Router RouterConfig `mapstructure:"router"`
 }
 
 // RouterConfig defines router configurations
 type RouterConfig struct {
-	REMBFeedback bool   `mapstructure:"subrembfeedback"`
-	MaxBandwidth uint64 `mapstructure:"maxbandwidth"`
-	MaxNackTime  int64  `mapstructure:"maxnacktime"`
+	REMBFeedback bool                      `mapstructure:"subrembfeedback"`
+	MaxBandwidth uint64                    `mapstructure:"maxbandwidth"`
+	MaxNackTime  int64                     `mapstructure:"maxnacktime"`
+	Video        WebRTCVideoReceiverConfig `mapstructure:"video"`
 }
 
 // SFU represents an sfu instance
@@ -61,8 +56,7 @@ func NewSFU(c Config) *SFU {
 		configuration: webrtc.Configuration{
 			SDPSemantics: webrtc.SDPSemanticsUnifiedPlan,
 		},
-		setting:  webrtc.SettingEngine{},
-		receiver: c.Receiver,
+		setting: webrtc.SettingEngine{},
 	}
 	// Init router config
 	routerConfig = c.Router
@@ -95,7 +89,7 @@ func NewSFU(c Config) *SFU {
 	w.configuration.ICEServers = iceServers
 
 	// Configure bandwidth estimation support
-	if c.Receiver.Video.TCCCycle > 0 {
+	if c.Router.Video.TCCCycle > 0 {
 		rtcpfb = append(rtcpfb, webrtc.RTCPFeedback{Type: webrtc.TypeRTCPFBTransportCC})
 		transportCCURL, _ := url.Parse(sdp.TransportCCURI)
 		exts := []sdp.ExtMap{
@@ -107,7 +101,7 @@ func NewSFU(c Config) *SFU {
 		w.setting.AddSDPExtensions(webrtc.SDPSectionVideo, exts)
 	}
 
-	if c.Receiver.Video.REMBCycle > 0 {
+	if c.Router.Video.REMBCycle > 0 {
 		rtcpfb = append(rtcpfb, webrtc.RTCPFeedback{Type: webrtc.TypeRTCPFBGoogREMB})
 	}
 

--- a/pkg/sfu_test.go
+++ b/pkg/sfu_test.go
@@ -23,9 +23,6 @@ func TestSFU(t *testing.T) {
 			Stats: true,
 		},
 		WebRTC: WebRTCConfig{},
-		Receiver: ReceiverConfig{
-			Video: WebRTCVideoReceiverConfig{},
-		},
 	})
 
 	me := webrtc.MediaEngine{}

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -3,7 +3,6 @@ package sfu
 import (
 	"context"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -20,7 +19,6 @@ const (
 // WebRTCTransportConfig represents configuration options
 type WebRTCTransportConfig struct {
 	configuration webrtc.Configuration
-	receiver      ReceiverConfig
 	setting       webrtc.SettingEngine
 }
 
@@ -76,13 +74,7 @@ func NewWebRTCTransport(ctx context.Context, session *Session, me MediaEngine, c
 
 	pc.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
 		log.Debugf("Peer %s got remote track id: %s ssrc: %d", p.id, track.ID(), track.SSRC())
-		var recv Receiver
-		switch track.Kind() {
-		case webrtc.RTPCodecTypeVideo:
-			recv = NewWebRTCVideoReceiver(ctx, cfg.receiver.Video, track)
-		case webrtc.RTPCodecTypeAudio:
-			recv = NewWebRTCAudioReceiver(track)
-		}
+		recv := NewWebRTCReceiver(ctx, track)
 
 		if recv.Track().Kind() == webrtc.RTPCodecTypeVideo {
 			go p.sendRTCP(recv)
@@ -93,7 +85,7 @@ func NewWebRTCTransport(ctx context.Context, session *Session, me MediaEngine, c
 
 		p.session.AddRouter(router)
 
-		router.OnClose(func() {
+		recv.OnCloseHandler(func() {
 			p.mu.Lock()
 			defer p.mu.Unlock()
 			delete(p.routers, track.SSRC())
@@ -281,21 +273,17 @@ func (p *WebRTCTransport) Close() error {
 }
 
 func (p *WebRTCTransport) sendRTCP(recv Receiver) {
+	rtcpCh := recv.ReadRTCP()
 	for {
-		pkt, err := recv.ReadRTCP()
-		if err == io.ErrClosedPipe {
-			return
-		}
-
-		if err != nil {
-			log.Errorf("Error reading RTCP %s", err)
-			continue
-		}
-
-		log.Tracef("sendRTCP %v", pkt)
-		err = p.pc.WriteRTCP([]rtcp.Packet{pkt})
-		if err != nil {
-			log.Errorf("Error writing RTCP %s", err)
+		select {
+		case pkt, opn := <-rtcpCh:
+			if !opn {
+				return
+			}
+			log.Tracef("sendRTCP %v", pkt)
+			if err := p.pc.WriteRTCP([]rtcp.Packet{pkt}); err != nil {
+				log.Errorf("Error writing RTCP %s", err)
+			}
 		}
 	}
 }

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -273,17 +273,10 @@ func (p *WebRTCTransport) Close() error {
 }
 
 func (p *WebRTCTransport) sendRTCP(recv Receiver) {
-	rtcpCh := recv.ReadRTCP()
-	for {
-		select {
-		case pkt, opn := <-rtcpCh:
-			if !opn {
-				return
-			}
-			log.Tracef("sendRTCP %v", pkt)
-			if err := p.pc.WriteRTCP([]rtcp.Packet{pkt}); err != nil {
-				log.Errorf("Error writing RTCP %s", err)
-			}
+	for pkt := range recv.ReadRTCP() {
+		log.Tracef("sendRTCP %v", pkt)
+		if err := p.pc.WriteRTCP([]rtcp.Packet{pkt}); err != nil {
+			log.Errorf("Error writing RTCP %s", err)
 		}
 	}
 }

--- a/pkg/webrtctransport.go
+++ b/pkg/webrtctransport.go
@@ -236,7 +236,7 @@ func (p *WebRTCTransport) NewSender(intrack *webrtc.Track) (Sender, error) {
 	// Create webrtc sender for the peer we are sending track to
 	sender := NewWebRTCSender(p.ctx, outtrack, s)
 
-	sender.OnClose(func() {
+	sender.OnCloseHandler(func() {
 		err = p.pc.RemoveTrack(s)
 		if err != nil {
 			log.Errorf("Error closing sender: %s", err)

--- a/pkg/webrtctransport_test.go
+++ b/pkg/webrtctransport_test.go
@@ -16,11 +16,6 @@ var conf = WebRTCTransportConfig{
 		SDPSemantics: webrtc.SDPSemanticsUnifiedPlan,
 	},
 	setting: webrtc.SettingEngine{},
-	receiver: ReceiverConfig{
-		Video: WebRTCVideoReceiverConfig{
-			REMBCycle: 1,
-		},
-	},
 }
 
 // newPair creates two new peer connections (an offerer and an answerer) using

--- a/pkg/webrtctransport_test.go
+++ b/pkg/webrtctransport_test.go
@@ -254,10 +254,10 @@ func TestPeerPairRemoteBGetsOnTrack(t *testing.T) {
 
 	<-trackBDone
 
-	remoteA.Close()
-	remoteB.Close()
-	peerA.Close()
-	peerB.Close()
+	assert.NoError(t, remoteA.Close())
+	assert.NoError(t, remoteB.Close())
+	assert.NoError(t, peerA.Close())
+	assert.NoError(t, peerB.Close())
 }
 
 func TestPeerPairRemoteAGetsOnTrackWhenRemoteBJoinsWithPub(t *testing.T) {

--- a/pkg/webrtctransport_test.go
+++ b/pkg/webrtctransport_test.go
@@ -556,7 +556,7 @@ func TestPeerRemovesRouterWhenRemoteRemovesTrack(t *testing.T) {
 	err = renegotiate(remote, peer)
 	assert.NoError(t, err)
 	router.close()
-
+	time.Sleep(50 * time.Millisecond)
 	router = peer.GetRouter(track.SSRC())
 	assert.Nil(t, router)
 


### PR DESCRIPTION
#### Description
This PR it's for simplify the relation between Receivers->Routers->Senders

-Receivers
1. Will close on  remote track removed or Close called.
2. Simplify to only have one single struct for video/audio. 
3. Errors are handled in receivers and not bubbled up.

-Routers
1. Routers will only fwd data between senders and receivers.
1. Routers will close themselves on receiver closed.

-Senders (TODO)
1. Senders will close on peer removed or track removed
2. Senders feedbacks will be directly forwarded and not calculated in SFU (Discussion required) and can be opted out.

Tests (TODO)
1. Make some minor changes to reflect these changes.

Breaking Changes:
None, so far the api reminds the same.

#### Reference issue
Fixes #177 
