### PR TITLE
Fix close senders on publisher leave, and delete subs on leave

### DIFF
--- a/pkg/receiver.go
+++ b/pkg/receiver.go
@@ -128,6 +128,7 @@ func (w *WebRTCReceiver) AddSender(sender Sender) {
 	w.senders[sender.ID()] = sender
 }
 
+//DeleteSender removes a Sender from a Receiver
 func (w *WebRTCReceiver) DeleteSender(pid string) {
 	w.Lock()
 	defer w.Unlock()
@@ -136,6 +137,15 @@ func (w *WebRTCReceiver) DeleteSender(pid string) {
 
 func (w *WebRTCReceiver) SpatialLayer() uint8 {
 	return w.spatialLayer
+}
+
+//closeSenders Close all senders from Receiver
+func (w *WebRTCReceiver) closeSenders() {
+	w.Lock()
+	defer w.Unlock()
+	for _, sender := range w.senders {
+		sender.Close()
+	}
 }
 
 // ReadRTCP read rtcp packets
@@ -419,6 +429,7 @@ func (w *WebRTCReceiver) stats() string {
 
 func startVideoReceiver(w *WebRTCReceiver, wStart chan struct{}, config RouterConfig) {
 	defer func() {
+		w.closeSenders()
 		w.buffer.Stop()
 		close(w.rtpCh)
 		close(w.rtcpCh)
@@ -465,6 +476,7 @@ func startVideoReceiver(w *WebRTCReceiver, wStart chan struct{}, config RouterCo
 
 func startAudioReceiver(w *WebRTCReceiver, wStart chan struct{}) {
 	defer func() {
+		w.closeSenders()
 		close(w.rtpCh)
 		if w.onCloseHandler != nil {
 			w.onCloseHandler()

--- a/pkg/receiver_test.go
+++ b/pkg/receiver_test.go
@@ -463,3 +463,47 @@ func TestWebRTCReceiver_fwdRTP(t *testing.T) {
 		})
 	}
 }
+
+func TestWebRTCReceiver_closeSenders(t *testing.T) {
+	closeChan := make(chan struct{}, 1)
+
+	fakeSender := SenderMock{
+		CloseFunc: func() {
+			closeChan <- struct{}{}
+		},
+	}
+
+	type fields struct {
+		senders map[string]Sender
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "Must call close methods on senders",
+			fields: fields{
+				senders: map[string]Sender{"test": &fakeSender},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &WebRTCReceiver{
+				senders: tt.fields.senders,
+			}
+			w.closeSenders()
+			tmr := time.NewTimer(100 * time.Millisecond)
+			for {
+				select {
+				case <-tmr.C:
+					t.Fatal("No close method called")
+				case <-closeChan:
+					tmr.Stop()
+					return
+				}
+
+			}
+		})
+	}
+}

--- a/pkg/receiver_test.go
+++ b/pkg/receiver_test.go
@@ -488,6 +488,7 @@ func TestWebRTCReceiver_closeSenders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			w := &WebRTCReceiver{
 				senders: tt.fields.senders,

--- a/pkg/sender.go
+++ b/pkg/sender.go
@@ -100,6 +100,10 @@ func (s *WebRTCSender) Close() {
 
 func (s *WebRTCSender) close() {
 	s.cancel()
+	// Remove sender from receiver
+	if recv := s.router.GetReceiver(0); recv != nil {
+		recv.DeleteSender(s.id)
+	}
 	if s.onCloseHandler != nil {
 		s.onCloseHandler()
 	}

--- a/pkg/sender_test.go
+++ b/pkg/sender_test.go
@@ -155,6 +155,8 @@ func TestWebRTCSender_receiveRTCP(t *testing.T) {
 			gotRTCP <- in1
 			return nil
 		},
+		DeleteSenderFunc: func(_ string) {
+		},
 	}
 
 	fakeRouter := &RouterMock{
@@ -244,10 +246,16 @@ forLoop:
 func TestWebRTCSender_Close(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	closeCtr := 0
+	fakeRouter := &RouterMock{
+		GetReceiverFunc: func(_ uint8) Receiver {
+			return nil
+		},
+	}
 
 	type fields struct {
 		ctx            context.Context
 		cancel         context.CancelFunc
+		router         Router
 		onCloseHandler func()
 	}
 	tests := []struct {
@@ -260,6 +268,7 @@ func TestWebRTCSender_Close(t *testing.T) {
 			fields: fields{
 				ctx:            ctx,
 				cancel:         cancel,
+				router:         fakeRouter,
 				onCloseHandler: nil,
 			},
 		},
@@ -269,6 +278,7 @@ func TestWebRTCSender_Close(t *testing.T) {
 			fields: fields{
 				ctx:    ctx,
 				cancel: cancel,
+				router: fakeRouter,
 				onCloseHandler: func() {
 					closeCtr++
 				},
@@ -281,6 +291,7 @@ func TestWebRTCSender_Close(t *testing.T) {
 			s := &WebRTCSender{
 				ctx:            tt.fields.ctx,
 				cancel:         tt.fields.cancel,
+				router:         tt.fields.router,
 				onCloseHandler: tt.fields.onCloseHandler,
 			}
 			if tt.fields.onCloseHandler == nil {

--- a/pkg/simulcastsender.go
+++ b/pkg/simulcastsender.go
@@ -217,6 +217,10 @@ func (s *WebRTCSimulcastSender) Close() {
 
 func (s *WebRTCSimulcastSender) close() {
 	s.cancel()
+	// Remove sender from receiver
+	if recv := s.router.GetReceiver(s.currentSpatialLayer); recv != nil {
+		recv.DeleteSender(s.id)
+	}
 	if s.onCloseHandler != nil {
 		s.onCloseHandler()
 	}

--- a/pkg/simulcastsender_test.go
+++ b/pkg/simulcastsender_test.go
@@ -312,10 +312,16 @@ forLoop:
 func TestWebRTCSimulcastSender_Close(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	closeCtr := 0
+	fakeRouter := &RouterMock{
+		GetReceiverFunc: func(_ uint8) Receiver {
+			return nil
+		},
+	}
 
 	type fields struct {
 		ctx            context.Context
 		cancel         context.CancelFunc
+		router         Router
 		onCloseHandler func()
 	}
 	tests := []struct {
@@ -328,6 +334,7 @@ func TestWebRTCSimulcastSender_Close(t *testing.T) {
 			fields: fields{
 				ctx:            ctx,
 				cancel:         cancel,
+				router:         fakeRouter,
 				onCloseHandler: nil,
 			},
 		},
@@ -337,6 +344,7 @@ func TestWebRTCSimulcastSender_Close(t *testing.T) {
 			fields: fields{
 				ctx:    ctx,
 				cancel: cancel,
+				router: fakeRouter,
 				onCloseHandler: func() {
 					closeCtr++
 				},
@@ -349,6 +357,7 @@ func TestWebRTCSimulcastSender_Close(t *testing.T) {
 			s := &WebRTCSimulcastSender{
 				ctx:            tt.fields.ctx,
 				cancel:         tt.fields.cancel,
+				router:         tt.fields.router,
 				onCloseHandler: tt.fields.onCloseHandler,
 			}
 			if tt.fields.onCloseHandler == nil {


### PR DESCRIPTION
#### Description

This commit fix the case when publishers tracks where not removed from senders on disconnect, and senders where not removed from publishers on disconnect.

