### PR TITLE
feat(senders): mute by default

### DIFF
--- a/pkg/simplesender.go
+++ b/pkg/simplesender.go
@@ -22,7 +22,7 @@ type SimpleSender struct {
 	sender         *webrtc.RTPSender
 	track          *webrtc.Track
 	router         Router
-	muted          atomicBool
+	enabled        atomicBool
 	payload        uint8
 	maxBitrate     uint64
 	target         uint64
@@ -62,7 +62,7 @@ func (s *SimpleSender) ID() string {
 
 // WriteRTP to the track
 func (s *SimpleSender) WriteRTP(pkt *rtp.Packet) {
-	if s.ctx.Err() != nil || s.muted.get() {
+	if s.ctx.Err() != nil || !s.enabled.get() {
 		return
 	}
 	if s.reSync.get() {
@@ -127,10 +127,10 @@ func (s *SimpleSender) WriteRTP(pkt *rtp.Packet) {
 }
 
 func (s *SimpleSender) Mute(val bool) {
-	if s.muted.get() == val {
+	if s.enabled.get() != val {
 		return
 	}
-	s.muted.set(val)
+	s.enabled.set(!val)
 	if val {
 		s.reSync.set(val)
 	}

--- a/pkg/simplesender_test.go
+++ b/pkg/simplesender_test.go
@@ -111,6 +111,7 @@ forLoop:
 				track:   senderTrack,
 			}
 			tmr := time.NewTimer(1000 * time.Millisecond)
+			s.Mute(false)
 			s.WriteRTP(fakePkt)
 			for {
 				pkt, err := remoteTrack.ReadRTP()
@@ -458,7 +459,7 @@ forLoop:
 	fakeRecv := &ReceiverMock{
 		WriteRTCPFunc: func(in1 rtcp.Packet) error {
 			if _, ok := in1.(*rtcp.PictureLossIndication); ok {
-				gotPli <- struct{}{}
+				close(gotPli)
 			}
 			return nil
 		},
@@ -472,6 +473,7 @@ forLoop:
 
 	simpleSdr := SimpleSender{
 		ctx:     context.Background(),
+		enabled: atomicBool{1},
 		router:  fakeRouter,
 		track:   senderTrack,
 		payload: senderTrack.PayloadType(),

--- a/pkg/simulcastsender_test.go
+++ b/pkg/simulcastsender_test.go
@@ -158,6 +158,7 @@ forLoop:
 			if tt.fields.checkPli {
 				s := &SimulcastSender{
 					ctx:           context.Background(),
+					enabled:       atomicBool{1},
 					router:        fakeRouter,
 					track:         senderTrack,
 					simulcastSSRC: simulcastSSRC,
@@ -178,6 +179,7 @@ forLoop:
 			if tt.fields.checkPacket {
 				s := &SimulcastSender{
 					ctx:           context.Background(),
+					enabled:       atomicBool{1},
 					router:        fakeRouter,
 					track:         senderTrack,
 					simulcastSSRC: simulcastSSRC,
@@ -276,6 +278,7 @@ forLoop:
 			wss := &SimulcastSender{
 				ctx:           ctx,
 				cancel:        cancel,
+				enabled:       atomicBool{1},
 				router:        fakeRouter,
 				sender:        s,
 				track:         senderTrack,
@@ -554,6 +557,7 @@ forLoop:
 
 	simpleSdr := SimulcastSender{
 		ctx:           context.Background(),
+		enabled:       atomicBool{1},
 		simulcastSSRC: 1234,
 		router:        fakeRouter,
 		track:         senderTrack,


### PR DESCRIPTION
senders start by default is a muted state. the client can unmute when it is ready for the rtp