### PR TITLE
feat: add combined grpc/json-rpc service for disk/browser examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor
 *.pem
 bin
 *.generated.go
+ion-sfu

--- a/README.md
+++ b/README.md
@@ -1,61 +1,41 @@
-<h1 align="center">
-  <br>
-  Ion SFU
-  <br>
-</h1>
-<h4 align="center">Go implementation of a WebRTC Selective Forwarding Unit</h4>
-<p align="center">
-  <a href="https://pion.ly/slack"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen" alt="Slack Widget"></a>
-  <a href="https://travis-ci.com/pion/ion-sfu"><img src="https://travis-ci.com/pion/ion-sfu.svg?branch=master" alt="Build Status"></a>
-  <a href="https://pkg.go.dev/github.com/pion/ion-sfu"><img src="https://godoc.org/github.com/pion/ion-sfu?status.svg" alt="GoDoc"></a>
-  <a href="https://codecov.io/gh/pion/ion-sfu"><img src="https://codecov.io/gh/pion/ion-sfu/branch/master/graph/badge.svg" alt="Coverage Status"></a>
-  <a href="https://goreportcard.com/report/github.com/pion/ion-sfu"><img src="https://goreportcard.com/badge/github.com/pion/ion-sfu" alt="Go Report Card"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-</p>
-<br>
+<a href="https://pion.ly/slack"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen" alt="Slack Widget"></a>
+<a href="https://travis-ci.com/pion/ion-sfu"><img src="https://travis-ci.com/pion/ion-sfu.svg?branch=master" alt="Build Status"></a>
+<a href="https://pkg.go.dev/github.com/pion/ion-sfu"><img src="https://godoc.org/github.com/pion/ion-sfu?status.svg" alt="GoDoc"></a>
+<a href="https://codecov.io/gh/pion/ion-sfu"><img src="https://codecov.io/gh/pion/ion-sfu/branch/master/graph/badge.svg" alt="Coverage Status"></a>
+<a href="https://goreportcard.com/report/github.com/pion/ion-sfu"><img src="https://goreportcard.com/badge/github.com/pion/ion-sfu" alt="Go Report Card"></a>
+<a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 
-A [selective forwarding unit](https://webrtcglossary.com/sfu/) is a video routing service which allows webrtc sessions to scale more efficiently. This package provides a simple, flexible, high performance Go implementation of a WebRTC SFU. It can be called directly or through a [gRPC](cmd/signal/grpc) or [json-rpc](cmd/signal/json-rpc) interface.
+# Ion SFU
 
-## Getting Started
+A [Selective Forwarding Unit](https://webrtcglossary.com/sfu/) is a video routing
+service which allows webrtc sessions to scale more efficiently. This package provides
+a simple, flexible, high performance Go implementation of a WebRTC SFU. It can
+be used as a library, or as a gprc/json-rpc [signalling service](cmd/server/).
 
-### Running the json-rpc signaling server
+## Usage
 
-If you have a local golang environment already setup, simply run
+Compile Ion-SFU and start it with modd(livereload):
 
-```
-go build ./cmd/signal/json-rpc/main.go && ./main -c config.toml
+```bash
+go build -o ion-sfu ./cmd/server/main.go && ./ion-sfu -c config.toml
+# Or using livereload during development:
+env GO111MODULE=on go get github.com/cortesi/modd/cmd/modd
+modd
 ```
 
-If you prefer a containerized environment, you can use the included Docker image
+If you prefer a containerized environment:
 
-```
+```bash
 docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pionwebrtc/ion-sfu:latest-jsonrpc
 ```
 
-### Running the grpc signaling server
+## Interacting with the server
 
-If you have a local golang environment already setup, simply run
+To get an idea of how to interact with the ion-sfu instance, check out the [ion examples](https://github.com/pion/ion-examples).
 
-```
-go build ./cmd/signal/grpc/main.go && ./main -c config.toml
-```
+## Processing Media
 
-If you prefer a containerized environment, you can use the included Docker image
-
-```
-docker run -p 50051:50051 -p 5000-5020:5000-5020/udp pionwebrtc/ion-sfu:latest-grpc
-```
-
-### Interacting with the server
-
-To get an idea of how to interact with the ion-sfu instance, check out our [examples](examples).
-
-### Processing Media
-
-`ion-sfu` supports real-time processing on media streamed through the sfu using [`ion-avp`](https://github.com/pion/ion-avp).
-
-For an example of recording a MediaStream to webm, checkout the [save-to-webm](https://github.com/pion/ion-avp/tree/master/examples/save-to-webm) example.
-
-### License
-
-MIT License - see [LICENSE](LICENSE) for full text
+`ion-sfu` supports real-time processing on media streamed through the sfu using
+[`ion-avp`](https://github.com/pion/ion-avp). For an example of recording a
+MediaStream to webm, checkout the [save-to-webm](https://github.com/pion/ion-avp/tree/master/examples/save-to-webm)
+example.

--- a/cmd/signal/main.go
+++ b/cmd/signal/main.go
@@ -1,0 +1,161 @@
+// Package cmd contains an entrypoint for running an ion-sfu instance.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"github.com/sourcegraph/jsonrpc2"
+	websocketjsonrpc2 "github.com/sourcegraph/jsonrpc2/websocket"
+	"github.com/spf13/viper"
+
+	grpcServer "github.com/pion/ion-sfu/cmd/signal/grpc/server"
+	jsonrpcServer "github.com/pion/ion-sfu/cmd/signal/json-rpc/server"
+	"google.golang.org/grpc"
+
+	pb "github.com/pion/ion-sfu/cmd/signal/grpc/proto"
+	sfu "github.com/pion/ion-sfu/pkg"
+	"github.com/pion/ion-sfu/pkg/log"
+)
+
+var (
+	conf     = sfu.Config{}
+	file     string
+	cert     string
+	key      string
+	jrpcAddr string
+	grpcAddr string
+)
+
+const (
+	portRangeLimit = 100
+)
+
+func showHelp() {
+	fmt.Printf("Usage:%s {params}\n", os.Args[0])
+	fmt.Println("      -c {config file}")
+	fmt.Println("      -cert {cert file}")
+	fmt.Println("      -key {key file}")
+	fmt.Println("      -a {listen grpcAddr}")
+	fmt.Println("      -a {listen jrpcAddr}")
+	fmt.Println("      -h (show help info)")
+}
+
+func load() bool {
+	_, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+
+	viper.SetConfigFile(file)
+	viper.SetConfigType("toml")
+
+	err = viper.ReadInConfig()
+	if err != nil {
+		fmt.Printf("config file %s read failed. %v\n", file, err)
+		return false
+	}
+	err = viper.GetViper().Unmarshal(&conf)
+	if err != nil {
+		fmt.Printf("sfu config file %s loaded failed. %v\n", file, err)
+		return false
+	}
+
+	if len(conf.WebRTC.ICEPortRange) > 2 {
+		fmt.Printf("config file %s loaded failed. range port must be [min,max]\n", file)
+		return false
+	}
+
+	if len(conf.WebRTC.ICEPortRange) != 0 && conf.WebRTC.ICEPortRange[1]-conf.WebRTC.ICEPortRange[0] < portRangeLimit {
+		fmt.Printf("config file %s loaded failed. range port must be [min, max] and max - min >= %d\n", file, portRangeLimit)
+		return false
+	}
+
+	fmt.Printf("config %s load ok!\n", file)
+	return true
+}
+
+func parse() bool {
+	flag.StringVar(&file, "c", "config.toml", "config file")
+	flag.StringVar(&cert, "cert", "", "cert file")
+	flag.StringVar(&key, "key", "", "key file")
+	flag.StringVar(&jrpcAddr, "j", ":7000", "address to use for JSON-RPC")
+	flag.StringVar(&grpcAddr, "g", ":50051", "address to use for GRPC")
+	help := flag.Bool("h", false, "help info")
+	flag.Parse()
+	if !load() {
+		return false
+	}
+
+	if *help {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if !parse() {
+		showHelp()
+		os.Exit(-1)
+	}
+	log.Init(conf.Log.Level, conf.Log.Fix)
+
+	log.Infof("--- Starting SFU Node ---")
+
+	lis, err := net.Listen("tcp", grpcAddr)
+
+	if err != nil {
+		log.Panicf("failed to listen: %v", err)
+	}
+
+	s := sfu.NewSFU(conf)
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
+
+	_s := grpc.NewServer()
+	inst := grpcServer.GRPCSignal{SFU: s}
+
+	pb.RegisterSFUService(_s, &pb.SFUService{
+		Signal: inst.Signal,
+	})
+
+	http.Handle("/ws", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			panic(err)
+		}
+		defer c.Close()
+
+		p := jsonrpcServer.NewJSONSignal(sfu.NewPeer(s))
+		defer p.Close()
+
+		jc := jsonrpc2.NewConn(r.Context(), websocketjsonrpc2.NewObjectStream(c), p)
+		<-jc.DisconnectNotify()
+	}))
+
+	go func() {
+		if key != "" && cert != "" {
+			log.Infof("Listening at https://[%s]", jrpcAddr)
+			err = http.ListenAndServeTLS(jrpcAddr, cert, key, nil)
+		} else {
+			log.Infof("Listening at http://[%s]", jrpcAddr)
+			err = http.ListenAndServe(jrpcAddr, nil)
+		}
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	if err := _s.Serve(lis); err != nil {
+		log.Panicf("failed to serve: %v", err)
+	}
+}


### PR DESCRIPTION
#### Description
It would be great if browser examples can be combined with examples that are run from disk.
The pub-from-disk example uses grpc, while the browser uses json-rpc. This PR tries to combine 
both signalling methods, so I can play an example movie from disk to the browser. Accompanying 
PR in examples: https://github.com/pion/ion-examples/pull/34

I'm rather new to Golang and Ion-Sfu. Please let me know if this PR needs more work. :)
Edit: Just read the contributing guidelines. Will try to polish things up later, so all tests pass.
