### PR TITLE
Remove the config assignment not being used

### DIFF
--- a/examples/echotest/index.html
+++ b/examples/echotest/index.html
@@ -300,14 +300,6 @@
       /* eslint-env browser */
       const joinBtns = document.getElementById("start-btns");
 
-      const config = {
-        iceServers: [
-          {
-            urls: "stun:stun.l.google.com:19302",
-          },
-        ],
-      };
-
       const signalLocal = new IonSDK.IonSFUJSONRPCSignal(
         "ws://localhost:7000/ws"
       );


### PR DESCRIPTION
#### Description

The variable `config` was assigned, but being used. 
In this example, as signaling process is being done via ion-sfu server, the `config` seems to serve no purpose.

If this was intended, sorry for bothering.

#### Reference issue
Fixes #252
