### PR TITLE
Fix sender start

### DIFF
--- a/pkg/router.go
+++ b/pkg/router.go
@@ -202,6 +202,15 @@ func (r *router) addSender(p *WebRTCTransport, rr *receiverRouter) error {
 			log.Errorf("Error closing sender: %s", err)
 		}
 	})
+	for _, t := range p.pc.GetTransceivers() {
+		if t.Sender() != nil && t.Sender().Track().SSRC() == ssrc {
+			p.pendingSenders.PushBack(&pendingSender{
+				transceiver: t,
+				sender:      sender,
+			})
+			break
+		}
+	}
 	p.AddSender(rr.stream, sender)
 	recv.AddSender(sender)
 	return nil


### PR DESCRIPTION
#### Description

This pr tries to solve the issue of not senders starting once negotiated. Transceivers were used to get pending mids, instead parsing the sdp, to prevent getting wrong info from SDP and parsing it 2 times.
