### PR TITLE
feat(sfu): Add memory ballast

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,9 @@
+[sfu]
+# Ballast size in MiB, will allocate memory to reduce the GC trigger upto 2x the
+# size of ballast. Be aware that the ballast should be less than the half of memory
+# available.
+ballast = 0
+
 [router]
 # Limit the remb bandwidth in kbps
 # zero means no limits

--- a/pkg/sfu.go
+++ b/pkg/sfu.go
@@ -14,11 +14,6 @@ import (
 	log "github.com/pion/ion-log"
 )
 
-//SFUConfig defines parameters for SFU server
-type SFUConfig struct {
-	Ballast int64 `mapstructure:"ballast"`
-}
-
 // ICEServerConfig defines parameters for ice servers
 type ICEServerConfig struct {
 	URLs       []string `mapstructure:"urls"`
@@ -35,7 +30,9 @@ type WebRTCConfig struct {
 
 // Config for base SFU
 type Config struct {
-	SFU    SFUConfig    `mapstructure:"sfu"`
+	SFU struct {
+		Ballast int64 `mapstructure:"ballast"`
+	} `mapstructure:"sfu"`
 	WebRTC WebRTCConfig `mapstructure:"webrtc"`
 	Log    log.Config   `mapstructure:"log"`
 	Router RouterConfig `mapstructure:"router"`

--- a/pkg/twcc_test.go
+++ b/pkg/twcc_test.go
@@ -1,7 +1,9 @@
 package sfu
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/pion/rtcp"
 	"github.com/stretchr/testify/assert"
@@ -323,4 +325,22 @@ func TestTccPacket(t1 *testing.T) {
 
 	assert.Equal(t1, hdr, ss.Header)
 
+}
+
+func BenchmarkBuildPacket(b *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	b.ReportAllocs()
+	n := 1 + rand.Intn(4-1+1)
+	var twcc TransportWideCC
+	tm := time.Now()
+	for i := 1; i < 100; i++ {
+		tm := tm.Add(time.Duration(60*n) * time.Millisecond)
+		twcc.tccExtInfo = append(twcc.tccExtInfo, rtpExtInfo{
+			ExtTSN:    uint32(i),
+			Timestamp: tm.UnixNano(),
+		})
+	}
+	for i := 0; i < b.N; i++ {
+		_ = twcc.buildTransportCCPacket()
+	}
 }


### PR DESCRIPTION
#### Description

This PR add a memory ballast configurable through config file. The SFU consist on sending and receiving many packets at high rate that are being allocated in heap, this may cause many gc pause per minute. The ballast will increase the size of GC target, effectiveling reducing this pauses
