### PR TITLE
WebRTCTransportConfig Breakout, only call session.onClosed once

### DIFF
--- a/pkg/session.go
+++ b/pkg/session.go
@@ -13,6 +13,7 @@ type Session struct {
 	mu             sync.RWMutex
 	transports     map[string]Transport
 	onCloseHandler func()
+	closed         bool
 }
 
 // NewSession creates a new session
@@ -20,6 +21,7 @@ func NewSession(id string) *Session {
 	return &Session{
 		id:         id,
 		transports: make(map[string]Transport),
+		closed:     false,
 	}
 }
 
@@ -39,8 +41,9 @@ func (s *Session) RemoveTransport(tid string) {
 	delete(s.transports, tid)
 
 	// Close session if no transports
-	if len(s.transports) == 0 && s.onCloseHandler != nil {
+	if len(s.transports) == 0 && s.onCloseHandler != nil && !s.closed {
 		s.onCloseHandler()
+		s.closed = true
 	}
 }
 

--- a/pkg/sfu.go
+++ b/pkg/sfu.go
@@ -51,12 +51,8 @@ type SFU struct {
 	sessions map[string]*Session
 }
 
-// NewSFU creates a new sfu instance
-func NewSFU(c Config) *SFU {
-	// Init random seed
-	rand.Seed(time.Now().UnixNano())
-	// Init ballast
-	ballast := make([]byte, c.SFU.Ballast*1024*1024)
+// NewWebRTCTransportConfig parses our settings and returns a usable WebRTCTransportConfig for creating PeerConnections
+func NewWebRTCTransportConfig(c Config) WebRTCTransportConfig {
 	se := webrtc.SettingEngine{}
 
 	// Configure required extensions
@@ -137,6 +133,18 @@ func NewSFU(c Config) *SFU {
 	if len(c.WebRTC.Candidates.NAT1To1IPs) > 0 {
 		w.setting.SetNAT1To1IPs(c.WebRTC.Candidates.NAT1To1IPs, webrtc.ICECandidateTypeHost)
 	}
+
+	return w
+}
+
+// NewSFU creates a new sfu instance
+func NewSFU(c Config) *SFU {
+	// Init random seed
+	rand.Seed(time.Now().UnixNano())
+	// Init ballast
+	ballast := make([]byte, c.SFU.Ballast*1024*1024)
+
+	w := NewWebRTCTransportConfig(c)
 
 	s := &SFU{
 		webrtc:   w,


### PR DESCRIPTION
#### Description
- This breaks out the WebrtcTransportConfig from NewSFU - which allows other packages to create their own sfu implementation
- Abstracts peer to use TransportProvider interface (for passing in a customized sfu.SFU{})
- Fixes issue where the session onClose callback gets triggered twice