### PR TITLE
Reorder calls to fix ice candidate not set when ice starts to trickle

### DIFF
--- a/cmd/signal/json-rpc/server/server.go
+++ b/cmd/signal/json-rpc/server/server.go
@@ -55,12 +55,6 @@ func (p *JSONSignal) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 			break
 		}
 
-		answer, err := p.Join(join.Sid, join.Offer)
-		if err != nil {
-			replyError(err)
-			break
-		}
-
 		p.OnOffer = func(offer *webrtc.SessionDescription) {
 			if err := conn.Notify(ctx, "offer", offer); err != nil {
 				log.Errorf("error sending offer %s", err)
@@ -74,6 +68,12 @@ func (p *JSONSignal) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 			}); err != nil {
 				log.Errorf("error sending ice candidate %s", err)
 			}
+		}
+
+		answer, err := p.Join(join.Sid, join.Offer)
+		if err != nil {
+			replyError(err)
+			break
 		}
 
 		_ = conn.Reply(ctx, req.ID, answer)


### PR DESCRIPTION
#### Description
The join before setting of the OnIceCandidate callback was causing an Ice candidate to not get sent in a very slim (1 out of 10) non deterministic manner.

#### Reference issue
I did not create an issue for this, but I can if you'd prefer. Its very similar to #347
