### PR TITLE
Remove the offer sdp from peer.Join. fix #409

### DIFF
--- a/cmd/signal/grpc/server/server.go
+++ b/cmd/signal/grpc/server/server.go
@@ -148,7 +148,7 @@ func (s *SFUServer) Signal(stream pb.SFU_SignalServer) error {
 				}
 			}
 
-			answer, err := peer.Join(payload.Join.Sid, offer)
+			err = peer.Join(payload.Join.Sid)
 			if err != nil {
 				switch err {
 				case sfu.ErrTransportExists:
@@ -168,6 +168,11 @@ func (s *SFUServer) Signal(stream pb.SFU_SignalServer) error {
 				default:
 					return status.Errorf(codes.Unknown, err.Error())
 				}
+			}
+
+			answer, err := peer.Answer(offer)
+			if err != nil {
+				return status.Errorf(codes.Internal, fmt.Sprintf("answer error: %v", err))
 			}
 
 			marshalled, err := json.Marshal(answer)

--- a/cmd/signal/json-rpc/server/server.go
+++ b/cmd/signal/json-rpc/server/server.go
@@ -70,7 +70,13 @@ func (p *JSONSignal) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 			}
 		}
 
-		answer, err := p.Join(join.Sid, join.Offer)
+		err = p.Join(join.Sid)
+		if err != nil {
+			replyError(err)
+			break
+		}
+
+		answer, err := p.Answer(join.Offer)
 		if err != nil {
 			replyError(err)
 			break

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -56,7 +56,7 @@ func NewPeer(provider SessionProvider) *Peer {
 	}
 }
 
-// Join initializes this peer for a given sessionID (takes an SDPOffer)
+// Join initializes this peer for a given sessionID
 func (p *Peer) Join(sid string) error {
 	if p.publisher != nil {
 		log.Debugf("peer already exists")

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -57,10 +57,10 @@ func NewPeer(provider SessionProvider) *Peer {
 }
 
 // Join initializes this peer for a given sessionID (takes an SDPOffer)
-func (p *Peer) Join(sid string, sdp webrtc.SessionDescription) (*webrtc.SessionDescription, error) {
+func (p *Peer) Join(sid string) error {
 	if p.publisher != nil {
 		log.Debugf("peer already exists")
-		return nil, ErrTransportExists
+		return ErrTransportExists
 	}
 
 	pid := cuid.New()
@@ -74,16 +74,16 @@ func (p *Peer) Join(sid string, sdp webrtc.SessionDescription) (*webrtc.SessionD
 
 	p.subscriber, err = NewSubscriber(pid, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating transport: %v", err)
+		return fmt.Errorf("error creating transport: %v", err)
 	}
 	p.publisher, err = NewPublisher(p.session, pid, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating transport: %v", err)
+		return fmt.Errorf("error creating transport: %v", err)
 	}
 
 	for _, dc := range p.session.datachannels {
 		if err := p.subscriber.AddDatachannel(p, dc); err != nil {
-			return nil, fmt.Errorf("error setting subscriber default dc datachannel")
+			return fmt.Errorf("error setting subscriber default dc datachannel")
 		}
 	}
 
@@ -156,16 +156,9 @@ func (p *Peer) Join(sid string, sdp webrtc.SessionDescription) (*webrtc.SessionD
 
 	log.Infof("peer %s join session %s", p.id, sid)
 
-	answer, err := p.publisher.Answer(sdp)
-	if err != nil {
-		return nil, fmt.Errorf("error setting remote description: %v", err)
-	}
-
-	log.Infof("peer %s send answer", p.id)
-
 	p.session.Subscribe(p)
 
-	return &answer, nil
+	return nil
 }
 
 // Answer an offer from remote

--- a/pkg/sfu/sfu_test.go
+++ b/pkg/sfu/sfu_test.go
@@ -377,8 +377,9 @@ func TestSFU_SessionScenarios(t *testing.T) {
 							err = p.remotePub.SetLocalDescription(offer)
 							assert.NoError(t, err)
 							<-gatherComplete
-							answer, err := p.local.Join("test", *p.remotePub.LocalDescription())
+							err = p.local.Join("test")
 							assert.NoError(t, err)
+							answer, err := p.local.Answer(*p.remotePub.LocalDescription())
 							err = p.remotePub.SetRemoteDescription(*answer)
 							assert.NoError(t, err)
 							p.mu.Unlock()


### PR DESCRIPTION
Separate the offer sdp parameter in the peer.Join method.
This allows for a more flexible signal design. The current modification does not affect the existing ion-sfu signaling but separates the first offer SDP from the join method. When the join fails, we don’t have to operate pc or create an offer on the client-side.

before:
```go
                       answer, err := peer.Join(payload.Join.Sid, offer)
                        if err != nil {
                                switch err {
                                case sfu.ErrTransportExists:
                               ...
                        }
```
after:
```go
                       err = peer.Join(payload.Join.Sid)
                        if err != nil {
                                switch err {
                                case sfu.ErrTransportExists:
                                  return sig.SendReply(JoinReply{Success: false, Error: sfu.ErrTransportExists })
                                case sfu.RoomIsFull:
                                  return sig.SendReply(JoinReply{Success: false, Error: sfu.RoomIsFull })
                                 ...
                        }
                        return sig.SendReply(JoinReply{Success: true, Error: nil })

                       ......

                       // recv description.
                       answer, err := peer.Answer(offer)
                       if err != nil {
                               return status.Errorf(codes.Internal, fmt.Sprintf("answer error: %v", err))
                       }
```


#### Reference issue
Fixes #409
