### PR TITLE
allow using custom buffer factory instead of package defaults

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -238,6 +238,9 @@ func (w *WebRTCReceiver) RetransmitPackets(track *DownTrack, packets []packetMet
 			}
 			pkt.Header.SequenceNumber = meta.getTargetSeqNo()
 			pkt.Header.Timestamp = meta.getTimestamp()
+			pkt.Header.SSRC = track.ssrc
+			pkt.Header.PayloadType = track.payloadType
+
 			if track.simulcast.temporalSupported {
 				switch track.mime {
 				case "video/vp8":


### PR DESCRIPTION
#### Description
Currently DownTrack relies on a package `bufferFactory` to respond to RTCP packets. Since I'm using a custom signaling layer, and feeding buffers manually into Receiver, I'm not able to access the sfu package's bufferFactory.

It seems cleaner to allow DownTrack to use custom a BufferFactory instead of assuming the package defaults.
