### PR TITLE
fix nack handling for downtracks, enable external bufferfactory

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -238,6 +238,9 @@ func (w *WebRTCReceiver) RetransmitPackets(track *DownTrack, packets []packetMet
 			}
 			pkt.Header.SequenceNumber = meta.getTargetSeqNo()
 			pkt.Header.Timestamp = meta.getTimestamp()
+			pkt.Header.SSRC = track.ssrc
+			pkt.Header.PayloadType = track.payloadType
+
 			if track.simulcast.temporalSupported {
 				switch track.mime {
 				case "video/vp8":


### PR DESCRIPTION
#### Description
I was experiencing freezes in my streams, and it turned out that browser has not been able to use the packets that were retransmitted due to incorrect SSRC and payloadType. This PR addresses it.

It also enables third-party bufferFactory, so I could go back to using ion-sfu instead of my forked copy for my project.
