### PR TITLE
Adding allrpc Github workflow

### DIFF
--- a/.github/workflows/docker-allrpc.yaml
+++ b/.github/workflows/docker-allrpc.yaml
@@ -1,0 +1,34 @@
+name: allrpc docker
+on:
+  push:
+    branches:
+    - master
+  release:
+    types: [published]
+  pull_request:
+    branches:
+    - master
+jobs:
+  build:
+    name: build and push
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v2
+    
+      - name: build
+        run: docker build --tag pionwebrtc/ion-sfu:latest-allrpc -f cmd/signal/allrpc/Dockerfile .
+
+      - name: login
+        if: github.event_name == 'release'
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: tag
+        if: github.event_name == 'release'
+        run: docker tag pionwebrtc/ion-sfu:latest-allrpc pionwebrtc/ion-sfu:"$TAG"-allrpc
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
+      - name: push
+        if: github.event_name == 'release'
+        run: docker push pionwebrtc/ion-sfu

--- a/.github/workflows/docker-allrpc.yaml
+++ b/.github/workflows/docker-allrpc.yaml
@@ -31,4 +31,6 @@ jobs:
 
       - name: push
         if: github.event_name == 'release'
-        run: docker push pionwebrtc/ion-sfu
+        run: docker push pionwebrtc/ion-sfu:latest-allrpc && docker push pionwebrtc/ion-sfu:"$TAG"-allrpc
+        env:
+          TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
#### Description

Github workflow for automatically pushing allrpc Docker image similar to what already happens with [jsonrpc](https://github.com/pion/ion-sfu/blob/master/.github/workflows/docker-jsonrpc.yaml) and [grpc](https://github.com/pion/ion-sfu/blob/master/.github/workflows/docker-grpc.yaml).

Docker image will then be available as `pionwebrtc/ion-sfu:latest-allrpc` on Dockerhub.
