### PR TITLE
add metadata field to peer structure

### DIFF
--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -47,12 +47,21 @@ type Peer struct {
 
 	remoteAnswerPending bool
 	negotiationPending  bool
+	metadata            interface{}
 }
 
 // NewPeer creates a new Peer for signaling with the given SFU
 func NewPeer(provider SessionProvider) *Peer {
 	return &Peer{
 		provider: provider,
+	}
+}
+
+// NewPeer creates a new Peer for signaling with the given SFU and metadata
+func NewPeerWithMetadata(provider SessionProvider, metadata interface{}) *Peer {
+	return &Peer{
+		provider: provider,
+		metadata: metadata,
 	}
 }
 
@@ -251,4 +260,8 @@ func (p *Peer) Session() *Session {
 // ID return the peer id
 func (p *Peer) ID() string {
 	return p.id
+}
+
+func (p *Peer) Metadata() interface{} {
+	return p.metadata
 }


### PR DESCRIPTION
#### Description

It can be set from backend code. It can consist any data, in order to help to filter queriable peers.
Example of usage: (Let's imagine I want to reimplement Zoom-like 40 free minutes feature)
```go
func closeNonPaid(session *sfu.Session) {
	for _, peer := range session.Peers() {
		if m := peer.Metadata(); m != nil {
			pi := m.(*PaymentInfo)
			if !enoughMoney(pi) {
				peer.Close()
				session.RemovePeer(peer.ID())
			}
		}
	}
}
```