### PR TITLE
fix: pubsubtest compose uses allrpc

### DIFF
--- a/examples/pubsubtest/docker-compose.yaml
+++ b/examples/pubsubtest/docker-compose.yaml
@@ -8,7 +8,8 @@ services:
       - 8000:80
 
   sfu:
-    image: pionwebrtc/ion-sfu:latest-jsonrpc
+    image: pionwebrtc/ion-sfu:latest-allrpc
+    command: -c /configs/sfu.toml -jaddr :7000 -gaddr :50051
     ports:
       - "5000-5200:5000-5200/udp"
       - 7000:7000


### PR DESCRIPTION
I was just made aware we provide this compose file in `pubsubtest` folder; if we use allrpc instead of jsonrpc, this makes a great entrypoint for introducing people to `ion-sdk-go`, `ion-avp` or `ion-app-flutter` (because jsonrpc is great for a simple pubsubtest, but everything else uses grpc)