### PR TITLE
feat(sfu): Add join configuration to peers

### DIFF
--- a/pkg/sfu/publisher.go
+++ b/pkg/sfu/publisher.go
@@ -39,8 +39,8 @@ func NewPublisher(session *Session, id string, cfg WebRTCTransportConfig) (*Publ
 	p := &Publisher{
 		id:      id,
 		pc:      pc,
-		session: session,
 		router:  newRouter(id, pc, session, cfg.router),
+		session: session,
 	}
 
 	pc.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
@@ -49,7 +49,7 @@ func NewPublisher(session *Session, id string, cfg WebRTCTransportConfig) (*Publ
 			"track_id", track.ID(),
 			"mediaSSRC", track.SSRC(),
 			"rid", track.RID(),
-			"stram_id", track.StreamID(),
+			"stream_id", track.StreamID(),
 		)
 
 		if r, pub := p.router.AddReceiver(receiver, track); pub {

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -84,7 +84,6 @@ func (r *router) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRe
 
 	publish := false
 	trackID := track.ID()
-	rid := track.RID()
 
 	buff, rtcpReader := r.bufferFactory.GetBufferPair(uint32(track.SSRC()))
 
@@ -164,17 +163,10 @@ func (r *router) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRe
 			}
 			r.deleteReceiver(trackID, uint32(track.SSRC()))
 		})
-		if len(rid) == 0 || r.config.Simulcast.BestQualityFirst && rid == fullResolution ||
-			!r.config.Simulcast.BestQualityFirst && rid == quarterResolution {
-			publish = true
-		}
-	} else if r.config.Simulcast.BestQualityFirst && rid == fullResolution ||
-		!r.config.Simulcast.BestQualityFirst && rid == quarterResolution ||
-		!r.config.Simulcast.BestQualityFirst && rid == halfResolution {
 		publish = true
 	}
 
-	recv.AddUpTrack(track, buff)
+	recv.AddUpTrack(track, buff, r.config.Simulcast.BestQualityFirst)
 
 	buff.Bind(receiver.GetParameters(), buffer.Options{
 		MaxBitRate: r.config.MaxBandwidth,

--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -96,7 +96,7 @@ func (s *Session) AddDatachannel(owner string, dc *webrtc.DataChannel) {
 	s.peers[owner].subscriber.channels[label] = dc
 	peers := make([]*Peer, 0, len(s.peers))
 	for _, p := range s.peers {
-		if p.id == owner {
+		if p.id == owner || p.subscriber == nil {
 			continue
 		}
 		peers = append(peers, p)
@@ -131,7 +131,7 @@ func (s *Session) Publish(router Router, r Receiver) {
 
 	for _, p := range peers {
 		// Don't sub to self
-		if router.ID() == p.id {
+		if router.ID() == p.id || p.subscriber == nil {
 			continue
 		}
 
@@ -151,7 +151,7 @@ func (s *Session) Subscribe(peer *Peer) {
 	copy(fdc, s.fanOutDCs)
 	peers := make([]*Peer, 0, len(s.peers))
 	for _, p := range s.peers {
-		if p == peer {
+		if p == peer || p.publisher == nil {
 			continue
 		}
 		peers = append(peers, p)


### PR DESCRIPTION
#### Description

Add join configuration to peers that will allow to disable publishing or subscribing, this will allow other services or relaying to not open useless peerconnections.

The configuration is optional hence backwards compatible.