### PR TITLE
feat(sfu): add join config to peers

### DIFF
--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -96,7 +96,7 @@ func (s *Session) AddDatachannel(owner string, dc *webrtc.DataChannel) {
 	s.peers[owner].subscriber.channels[label] = dc
 	peers := make([]*Peer, 0, len(s.peers))
 	for _, p := range s.peers {
-		if p.id == owner {
+		if p.id == owner || p.subscriber == nil {
 			continue
 		}
 		peers = append(peers, p)
@@ -131,7 +131,7 @@ func (s *Session) Publish(router Router, r Receiver) {
 
 	for _, p := range peers {
 		// Don't sub to self
-		if router.ID() == p.id {
+		if router.ID() == p.id || p.subscriber == nil {
 			continue
 		}
 
@@ -151,7 +151,7 @@ func (s *Session) Subscribe(peer *Peer) {
 	copy(fdc, s.fanOutDCs)
 	peers := make([]*Peer, 0, len(s.peers))
 	for _, p := range s.peers {
-		if p == peer {
+		if p == peer || p.publisher == nil {
 			continue
 		}
 		peers = append(peers, p)


### PR DESCRIPTION
#### Description

Add join configuration to peers that will allow to disable publishing or subscribing, this will allow other services or relaying to not open useless peerconnections.

The configuration is optional hence backwards compatible.