### PR TITLE
Browser autoplay policy work around.

### DIFF
--- a/examples/pubsubtest/index.html
+++ b/examples/pubsubtest/index.html
@@ -37,18 +37,6 @@
           </button>
         </div>
       </div>
-      <div class="row" id="enable-audio">
-        <div class="col-12">
-          <button
-            type="button"
-            class="btn btn-primary"
-            id="enable-audio-button"
-            onclick="enableAudio(false)"
-          >
-            Enable Audio
-          </button>
-        </div>
-      </div>
 
       <div class="row">
         <div class="col-6 pt-2">
@@ -121,11 +109,20 @@
           </div>
         </div>
         <div id="remotes" class="col-6 pt-2">
-          <span
-            style="position: absolute; margin-left: 5px; margin-top: 5px"
-            class="badge badge-primary"
-            >Remotes</span
-          >
+          <span class="badge badge-primary">Remotes</span>
+
+          <div class="row" id="enable-audio">
+            <div class="col-12">
+              <button
+                type="button"
+                class="btn btn-primary"
+                id="enable-audio-button"
+                onclick="enableAudio(false)"
+              >
+                Enable Audio
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/examples/pubsubtest/index.html
+++ b/examples/pubsubtest/index.html
@@ -33,7 +33,19 @@
       <div class="row" id="start-btns">
         <div class="col-12">
           <button type="button" class="btn btn-primary" onclick="start(false)">
-            start
+            Publish
+          </button>
+        </div>
+      </div>
+      <div class="row" id="enable-audio">
+        <div class="col-12">
+          <button
+            type="button"
+            class="btn btn-primary"
+            id="enable-audio-button"
+            onclick="enableAudio(false)"
+          >
+            Enable Audio
           </button>
         </div>
       </div>
@@ -136,82 +148,6 @@
     ></script>
     <script src="https://unpkg.com/ion-sdk-js@1.5.5/dist/ion-sdk.min.js"></script>
     <script src="https://unpkg.com/ion-sdk-js@1.5.5/dist/json-rpc.min.js"></script>
-    <script>
-      const localVideo = document.getElementById("local-video");
-      const remotesDiv = document.getElementById("remotes");
-
-      /* eslint-env browser */
-      const joinBtns = document.getElementById("start-btns");
-
-      const config = {
-        iceServers: [
-          {
-            urls: "stun:stun.l.google.com:19302",
-          },
-        ],
-      };
-
-      const signalLocal = new Signal.IonSFUJSONRPCSignal(
-        "ws://localhost:7000/ws"
-      );
-
-      const clientLocal = new IonSDK.Client(signalLocal, config);
-      signalLocal.onopen = () => clientLocal.join("test session");
-
-      const streams = {};
-      let localStream;
-      const start = () => {
-        IonSDK.LocalStream.getUserMedia({
-          resolution: "vga",
-          audio: true,
-        })
-          .then((media) => {
-            localStream = media;
-            localVideo.srcObject = media;
-            localVideo.autoplay = true;
-            localVideo.controls = true;
-            localVideo.muted = true;
-            joinBtns.style.display = "none";
-            clientLocal.publish(media);
-          })
-          .catch(console.error);
-      };
-
-      clientLocal.ontrack = (track, stream) => {
-        console.log("got track", track.id, "for stream", stream.id);
-        if (track.kind === "video") {
-          track.onunmute = () => {
-            if (!streams[stream.id]) {
-              remoteVideo = document.createElement("video");
-              remoteVideo.srcObject = stream;
-              remoteVideo.autoplay = true;
-              remoteVideo.muted = true;
-
-              remotesDiv.appendChild(remoteVideo);
-              stream.onremovetrack = () => {
-                remotesDiv.removeChild(remoteVideo);
-                streams[stream.id] = null;
-              };
-            }
-          };
-        }
-      };
-
-      const controlLocalVideo = (radio) => {
-        if (radio.value === "false") {
-          localStream.mute("video");
-        } else {
-          localStream.unmute("video");
-        }
-      };
-
-      const controlLocalAudio = (radio) => {
-        if (radio.value === "false") {
-          localStream.mute("audio");
-        } else {
-          localStream.unmute("audio");
-        }
-      };
-    </script>
+    <script src="./main.js"></script>
   </body>
 </html>

--- a/examples/pubsubtest/main.js
+++ b/examples/pubsubtest/main.js
@@ -1,0 +1,120 @@
+const localVideo = document.getElementById("local-video");
+const remotesDiv = document.getElementById("remotes");
+
+const serverUrl = "ws://localhost:7000/ws";
+
+/* eslint-env browser */
+const joinBtns = document.getElementById("start-btns");
+
+const config = {
+  iceServers: [
+    {
+      urls: "stun:stun.l.google.com:19302",
+    },
+  ],
+};
+
+const signalLocal = new Signal.IonSFUJSONRPCSignal(serverUrl);
+
+const clientLocal = new IonSDK.Client(signalLocal, config);
+signalLocal.onopen = () => clientLocal.join("test session");
+
+/**
+ * For every remote stream this object will hold the follwing information:
+ * {
+ *  "id-of-the-remote-stream": {
+ *     stream: [Object], // Reference to the stream object
+ *     videoElement: [Object] // Reference to the video element that's rendering the stream.
+ *   }
+ * }
+ */
+const streams = {};
+
+/**
+ * When we click the Enable Audio button this function gets called, and
+ * unmutes all the remote videos that might be there and also any future ones.
+ * This little party trick is according to
+ * https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide.
+ */
+let remoteVideoIsMuted = true;
+function enableAudio() {
+  if (remoteVideoIsMuted) {
+    // Unmute all the current videoElements.
+    for (const streamInfo of Object.values(streams)) {
+      let { videoElement } = streamInfo;
+      videoElement.pause();
+      videoElement.muted = false;
+      videoElement.play();
+    }
+    // Set remoteVideoIsMuted to false so that all future autoplays
+    // work.
+    remoteVideoIsMuted = false;
+
+    const button = document.getElementById("enable-audio-button");
+    button.remove();
+  }
+}
+
+let localStream;
+const start = () => {
+  IonSDK.LocalStream.getUserMedia({
+    resolution: "vga",
+    audio: true,
+  })
+    .then((media) => {
+      localStream = media;
+      localVideo.srcObject = media;
+      localVideo.autoplay = true;
+      localVideo.controls = true;
+      localVideo.muted = true;
+      joinBtns.style.display = "none";
+      clientLocal.publish(media);
+    })
+    .catch(console.error);
+};
+
+clientLocal.ontrack = (track, stream) => {
+  console.log("got track", track.id, "for stream", stream.id);
+  track.onunmute = () => {
+    // If the stream is not there in the streams map.
+    if (!streams[stream.id]) {
+      // Create a video element for rendering the stream
+      remoteVideo = document.createElement("video");
+      remoteVideo.srcObject = stream;
+      remoteVideo.autoplay = true;
+      remoteVideo.muted = remoteVideoIsMuted;
+      remotesDiv.appendChild(remoteVideo);
+
+      // Save the stream and video element in the map.
+      streams[stream.id] = { stream, videoElement: remoteVideo };
+
+      // When this stream removes a track, assume
+      // that its going away and remove it.
+      stream.onremovetrack = () => {
+        try {
+          if (streams[stream.id]) {
+            const { videoElement } = streams[stream.id];
+            remotesDiv.removeChild(videoElement);
+            delete streams[stream.id];
+          }
+        } catch (err) {}
+      };
+    }
+  };
+};
+
+const controlLocalVideo = (radio) => {
+  if (radio.value === "false") {
+    localStream.mute("video");
+  } else {
+    localStream.unmute("video");
+  }
+};
+
+const controlLocalAudio = (radio) => {
+  if (radio.value === "false") {
+    localStream.mute("audio");
+  } else {
+    localStream.unmute("audio");
+  }
+};


### PR DESCRIPTION
#### Description
The 'pubsubtest' demo in its current form lacks audio from the remote elements. That's because the muted property on the video elements is true. We can only set muted to 'false' if the user has at least once interacted with the document, and hence usually a CTA like 'Enable Audio' or 'Join with Audio' is normally used.

More info: https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide

This PR implementes an 'Enable Audio' button that will enable audio for all the remote streams, present or future. 

PS: Refactored inline js code into a 'main.js' file.
