### PR TITLE
Simulcast: Allow layer selection for publisher

### DIFF
--- a/pkg/middlewares/datachannel/subscriberapi.go
+++ b/pkg/middlewares/datachannel/subscriberapi.go
@@ -3,23 +3,92 @@ package datachannel
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pion/ion-sfu/pkg/sfu"
 	"github.com/pion/webrtc/v3"
 )
 
 const (
-	highValue   = "high"
-	mediumValue = "medium"
-	lowValue    = "low"
-	mutedValue  = "none"
+	highValue         = "high"
+	mediumValue       = "medium"
+	lowValue          = "low"
+	mutedValue        = "none"
+	ActiveLayerMethod = "activeLayer"
 )
 
 type setRemoteMedia struct {
-	StreamID  string `json:"streamId"`
-	Video     string `json:"video"`
-	Framerate string `json:"framerate"`
-	Audio     bool   `json:"audio"`
+	StreamID  string   `json:"streamId"`
+	Video     string   `json:"video"`
+	Framerate string   `json:"framerate"`
+	Audio     bool     `json:"audio"`
+	Layers    []string `json:"layers"`
+}
+
+type activeLayerMessage struct {
+	StreamID        string   `json:"streamId"`
+	ActiveLayer     string   `json:"activeLayer"`
+	AvailableLayers []string `json:"availableLayers"`
+}
+
+func layerStrToInt(layer string) (int, error) {
+	switch layer {
+	case highValue:
+		return 2, nil
+	case mediumValue:
+		return 1, nil
+	case lowValue:
+		return 0, nil
+	default:
+		// unknown value
+		return -1, fmt.Errorf("Unknown value")
+	}
+}
+
+func layerIntToStr(layer int) (string, error) {
+	switch layer {
+	case 0:
+		return lowValue, nil
+	case 1:
+		return mediumValue, nil
+	case 2:
+		return highValue, nil
+	default:
+		return "", fmt.Errorf("Unknown value: %d", layer)
+	}
+}
+
+func transformLayers(layers []string) ([]uint16, error) {
+	res := make([]uint16, len(layers))
+	for _, layer := range layers {
+		if l, err := layerStrToInt(layer); err == nil {
+			res = append(res, uint16(l))
+		} else {
+			return nil, fmt.Errorf("Unknown layer value: %v", layer)
+		}
+	}
+	return res, nil
+}
+
+func sendMessage(streamID string, peer *sfu.Peer, layers []string, activeLayer int) {
+	al, _ := layerIntToStr(activeLayer)
+	payload := activeLayerMessage{
+		StreamID:        streamID,
+		ActiveLayer:     al,
+		AvailableLayers: layers,
+	}
+	msg := sfu.ChannelAPIMessage{
+		Method: ActiveLayerMethod,
+		Params: payload,
+	}
+	bytes, err := json.Marshal(msg)
+	if err != nil {
+		sfu.Logger.Error(err, "unable to marshal active layer message")
+	}
+
+	if err := peer.SendAPIChannelMessage(&bytes); err != nil {
+		sfu.Logger.Error(err, "unable to send ActiveLayerMessage to peer", "peer_id", peer.ID())
+	}
 }
 
 func SubscriberAPI(next sfu.MessageProcessor) sfu.MessageProcessor {
@@ -28,35 +97,59 @@ func SubscriberAPI(next sfu.MessageProcessor) sfu.MessageProcessor {
 		if err := json.Unmarshal(args.Message.Data, srm); err != nil {
 			return
 		}
-		downTracks := args.Peer.Subscriber().GetDownTracks(srm.StreamID)
-		for _, dt := range downTracks {
-			switch dt.Kind() {
-			case webrtc.RTPCodecTypeAudio:
-				dt.Mute(!srm.Audio)
-			case webrtc.RTPCodecTypeVideo:
-				switch srm.Video {
-				case highValue:
-					dt.Mute(false)
-					dt.SwitchSpatialLayer(2, true)
-				case mediumValue:
-					dt.Mute(false)
-					dt.SwitchSpatialLayer(1, true)
-				case lowValue:
-					dt.Mute(false)
-					dt.SwitchSpatialLayer(0, true)
-				case mutedValue:
-					dt.Mute(true)
-				}
-				switch srm.Framerate {
-				case highValue:
-					dt.SwitchTemporalLayer(2, true)
-				case mediumValue:
-					dt.SwitchTemporalLayer(1, true)
-				case lowValue:
-					dt.SwitchTemporalLayer(0, true)
-				}
+		// Publisher changing active layers
+		if srm.Layers != nil && len(srm.Layers) > 0 {
+			layers, err := transformLayers(srm.Layers)
+			if err != nil {
+				sfu.Logger.Error(err, "error reading layers")
+				next.Process(ctx, args)
+				return
 			}
 
+			session := args.Peer.Session()
+			peers := session.Peers()
+			for _, peer := range peers {
+				if peer.ID() != args.Peer.ID() {
+					downTracks := peer.Subscriber().GetDownTracks(srm.StreamID)
+					for _, dt := range downTracks {
+						if dt.Kind() == webrtc.RTPCodecTypeVideo {
+							newLayer, _ := dt.UptrackLayersChange(layers)
+							sendMessage(srm.StreamID, peer, srm.Layers, int(newLayer))
+						}
+					}
+				}
+			}
+		} else {
+			downTracks := args.Peer.Subscriber().GetDownTracks(srm.StreamID)
+			for _, dt := range downTracks {
+				switch dt.Kind() {
+				case webrtc.RTPCodecTypeAudio:
+					dt.Mute(!srm.Audio)
+				case webrtc.RTPCodecTypeVideo:
+					switch srm.Video {
+					case highValue:
+						dt.Mute(false)
+						dt.SwitchSpatialLayer(2, true)
+					case mediumValue:
+						dt.Mute(false)
+						dt.SwitchSpatialLayer(1, true)
+					case lowValue:
+						dt.Mute(false)
+						dt.SwitchSpatialLayer(0, true)
+					case mutedValue:
+						dt.Mute(true)
+					}
+					switch srm.Framerate {
+					case highValue:
+						dt.SwitchTemporalLayer(2, true)
+					case mediumValue:
+						dt.SwitchTemporalLayer(1, true)
+					case lowValue:
+						dt.SwitchTemporalLayer(0, true)
+					}
+				}
+
+			}
 		}
 		next.Process(ctx, args)
 	})

--- a/pkg/middlewares/datachannel/subscriberapi.go
+++ b/pkg/middlewares/datachannel/subscriberapi.go
@@ -70,7 +70,7 @@ func transformLayers(layers []string) ([]uint16, error) {
 	return res, nil
 }
 
-func sendMessage(streamID string, peer *sfu.Peer, layers []string, activeLayer int) {
+func sendMessage(streamID string, peer sfu.Peer, layers []string, activeLayer int) {
 	al, _ := layerIntToStr(activeLayer)
 	payload := activeLayerMessage{
 		StreamID:        streamID,

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -30,6 +30,7 @@ type Peer interface {
 	Publisher() *Publisher
 	Subscriber() *Subscriber
 	Close() error
+	SendAPIChannelMessage(msg *[]byte) error
 }
 
 // JoinConfig allow adding more control to the peers joining a SessionLocal.
@@ -246,7 +247,7 @@ func (p *PeerLocal) Trickle(candidate webrtc.ICECandidateInit, target int) error
 	return nil
 }
 
-func (p *Peer) SendAPIChannelMessage(msg *[]byte) error {
+func (p *PeerLocal) SendAPIChannelMessage(msg *[]byte) error {
 	if p.subscriber == nil {
 		return fmt.Errorf("No subscriber for this peer")
 	}

--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -22,6 +22,7 @@ type Session interface {
 	GetDCMiddlewares() []*Datachannel
 	GetDataChannelLabels() []string
 	GetDataChannels(origin, label string) (dcs []*webrtc.DataChannel)
+	Peers() []Peer
 }
 
 type SessionLocal struct {

--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -35,6 +35,10 @@ type SessionLocal struct {
 	onCloseHandler func()
 }
 
+const (
+	AudioLevelsMethod = "audioLevels"
+)
+
 // NewSession creates a new SessionLocal
 func NewSession(id string, dcs []*Datachannel, cfg WebRTCTransportConfig) Session {
 	s := &SessionLocal{
@@ -45,7 +49,6 @@ func NewSession(id string, dcs []*Datachannel, cfg WebRTCTransportConfig) Sessio
 	}
 	go s.audioLevelObserver(cfg.Router.AudioLevelInterval)
 	return s
-
 }
 
 // ID return SessionLocal id
@@ -251,7 +254,12 @@ func (s *SessionLocal) audioLevelObserver(audioLevelInterval int) {
 			continue
 		}
 
-		l, err := json.Marshal(&levels)
+		msg := ChannelAPIMessage{
+			Method: AudioLevelsMethod,
+			Params: levels,
+		}
+
+		l, err := json.Marshal(&msg)
 		if err != nil {
 			Logger.Error(err, "Marshaling audio levels err")
 			continue


### PR DESCRIPTION
#### Description
* Allow publisher to select which layer(s) should be enabled. 
* Publisher can activate/deactivate layer with encoding params of the sender, however, there is no easy way to detect if a layer is enabled or not on sfu side. I added another message to middleware that will allow publishers to select which layer(s) are currently active on the sender side. It updates all the down tracks accordingly. 
* Message is then fanned out to all subscribers, so they are aware which layer is active and which ones are available. 
* In order to send messages on 'ion-sfu' channel (besides audio levels), I added a little bit more robust messaging type (similar to json-rpc). This is a breaking change for the client, unfortunately, but it gives us more flexibility if any new message type needs to be added in the future.

#### Reference issue
Fixes #...
