### PR TITLE
Add `StartRemoteTracksMuted` join option

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -42,14 +42,13 @@ type DownTrack struct {
 	spatialLayer  int32
 	temporalLayer int32
 
-	startMuted bool
-	enabled    atomicBool
-	reSync     atomicBool
-	snOffset   uint16
-	tsOffset   uint32
-	lastSSRC   uint32
-	lastSN     uint16
-	lastTS     uint32
+	enabled  atomicBool
+	reSync   atomicBool
+	snOffset uint16
+	tsOffset uint32
+	lastSSRC uint32
+	lastSN   uint16
+	lastTS   uint32
 
 	simulcast        simulcastTrackHelpers
 	maxSpatialLayer  int64
@@ -71,7 +70,7 @@ type DownTrack struct {
 }
 
 // NewDownTrack returns a DownTrack.
-func NewDownTrack(c webrtc.RTPCodecCapability, r Receiver, bf *buffer.Factory, peerID string, mt int, startMuted bool) (*DownTrack, error) {
+func NewDownTrack(c webrtc.RTPCodecCapability, r Receiver, bf *buffer.Factory, peerID string, mt int, enabled bool) (*DownTrack, error) {
 	return &DownTrack{
 		id:            r.TrackID(),
 		peerID:        peerID,
@@ -80,7 +79,7 @@ func NewDownTrack(c webrtc.RTPCodecCapability, r Receiver, bf *buffer.Factory, p
 		bufferFactory: bf,
 		receiver:      r,
 		codec:         c,
-		startMuted:    startMuted,
+		enabled:       newAtomicBool(enabled),
 	}, nil
 }
 
@@ -95,9 +94,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 		d.writeStream = t.WriteStream()
 		d.mime = strings.ToLower(codec.MimeType)
 		d.reSync.set(true)
-		if !d.enabled.get() {
-			d.enabled.set(!d.startMuted)
-		}
 		if rr := d.bufferFactory.GetOrNew(packetio.RTCPBufferPacket, uint32(t.SSRC())).(*buffer.RTCPReader); rr != nil {
 			rr.OnPacket(func(pkt []byte) {
 				d.handleRTCP(pkt)

--- a/pkg/sfu/helpers.go
+++ b/pkg/sfu/helpers.go
@@ -15,6 +15,14 @@ const (
 
 type atomicBool int32
 
+func newAtomicBool(value bool) atomicBool {
+	var i int32
+	if value {
+		i = 1
+	}
+	return atomicBool(i)
+}
+
 func (a *atomicBool) set(value bool) {
 	var i int32
 	if value {

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -30,6 +30,8 @@ type JoinConfig struct {
 	NoPublish bool
 	// If true the peer will not be allowed to subscribe to other peers in session.
 	NoSubscribe bool
+	// If true remote tracks will start muted. The peer can selectively unmunte tracks using the Subscriber API.
+	StartRemoteTracksMuted bool
 }
 
 // SessionProvider provides the session to the sfu.Peer{}
@@ -130,7 +132,9 @@ func (p *Peer) Join(sid, uid string, config ...JoinConfig) error {
 	}
 
 	if !conf.NoPublish {
-		p.publisher, err = NewPublisher(p.session, uid, cfg)
+		p.publisher, err = NewPublisher(p.session, uid, cfg, routerOptions{
+			startTracksMuted: conf.StartRemoteTracksMuted,
+		})
 		if err != nil {
 			return fmt.Errorf("error creating transport: %v", err)
 		}

--- a/pkg/sfu/publisher.go
+++ b/pkg/sfu/publisher.go
@@ -21,7 +21,7 @@ type Publisher struct {
 }
 
 // NewPublisher creates a new Publisher
-func NewPublisher(session *Session, id string, cfg WebRTCTransportConfig) (*Publisher, error) {
+func NewPublisher(session *Session, id string, cfg WebRTCTransportConfig, routerOptions routerOptions) (*Publisher, error) {
 	me, err := getPublisherMediaEngine()
 	if err != nil {
 		Logger.Error(err, "NewPeer error", "peer_id", id)
@@ -39,7 +39,7 @@ func NewPublisher(session *Session, id string, cfg WebRTCTransportConfig) (*Publ
 	p := &Publisher{
 		id:      id,
 		pc:      pc,
-		router:  newRouter(id, pc, session, cfg.router),
+		router:  newRouter(id, pc, session, cfg.router, routerOptions),
 		session: session,
 	}
 

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -231,7 +231,7 @@ func (r *router) addDownTrack(sub *Subscriber, recv Receiver) error {
 		Channels:     codec.Channels,
 		SDPFmtpLine:  codec.SDPFmtpLine,
 		RTCPFeedback: []webrtc.RTCPFeedback{{"goog-remb", ""}, {"nack", ""}, {"nack", "pli"}},
-	}, recv, r.bufferFactory, sub.id, r.config.MaxPacketTrack, r.options.startTracksMuted)
+	}, recv, r.bufferFactory, sub.id, r.config.MaxPacketTrack, !r.options.startTracksMuted)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds a new join option, `StartRemoteTracksMuted`.  When set to true, the peer's remote tracks will start off in the muted state.  This makes it easier for a peer to selectively receive some remote tracks while ignoring others.

As part of this change, the initial enabled/disabled state of a `DownTrack` is now set on create, rather than `Bind`.  This is to help with cases where a client sets a track's state early on (such as in an `ontrack` handler).  Previously if the state was set before `Bind` it would be lost, which made it harder for clients to select their tracks reliably.