### PR TITLE
feat: pubsubtest parameters for session and codec

### DIFF
--- a/examples/pubsubtest/main.js
+++ b/examples/pubsubtest/main.js
@@ -1,6 +1,8 @@
 const localVideo = document.getElementById("local-video");
 const remotesDiv = document.getElementById("remotes");
 
+const params = new URLSearchParams(window.location.search)
+
 const serverUrl = "ws://localhost:7000/ws";
 
 /* eslint-env browser */
@@ -17,7 +19,7 @@ const config = {
 const signalLocal = new Signal.IonSFUJSONRPCSignal(serverUrl);
 
 const clientLocal = new IonSDK.Client(signalLocal, config);
-signalLocal.onopen = () => clientLocal.join("test session");
+signalLocal.onopen = () => clientLocal.join(params.has("session") ? params.get("session") : "test session");
 
 /**
  * For every remote stream this object will hold the follwing information:
@@ -60,6 +62,7 @@ const start = () => {
   IonSDK.LocalStream.getUserMedia({
     resolution: "vga",
     audio: true,
+    codec: params.has("codec") ? params.get("codec") : "vp8",
   })
     .then((media) => {
       localStream = media;


### PR DESCRIPTION
Support `?session=myroom` and `?codec=h264` in pubsubtest parameters -- this examples gets used a lot in testing (and in the `pion/ion` project, the default room is "test room" rather than "test session"); it's convenient to be able to set these values on the fly without editing the file.