### PR TITLE
Fix issue with h264 layer switch in simulcast

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -345,12 +345,11 @@ func (w *WebRTCReceiver) writeRTP(layer int) {
 		w.locks[layer].Lock()
 
 		if w.isSimulcast && len(w.pendingTracks[layer]) > 0 {
-			if pkt.KeyFrame {
-				w.downTracks[layer] = append(w.downTracks[layer], w.pendingTracks[layer]...)
-				w.pendingTracks[layer] = w.pendingTracks[layer][:0]
-			} else {
+			if !pkt.KeyFrame {
 				w.SendRTCP(pli)
 			}
+			w.downTracks[layer] = append(w.downTracks[layer], w.pendingTracks[layer]...)
+			w.pendingTracks[layer] = w.pendingTracks[layer][:0]
 		}
 
 		for idx, dt := range w.downTracks[layer] {


### PR DESCRIPTION
* When we are making receiver initiated layer switch in simulcast using preferLayer() and h264 codec, we usually get artifact in stream due to missing keyframe.
* Switching layer immidiatelly and sending pli (instead of waiting for keyframe) fixes the issue.

#### Description

#### Reference issue
Fixes #...
