### PR TITLE
feat(sfu): add webrtc timeouts config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,6 +70,14 @@ mdns = true
 # nat1to1 = ["1.2.3.4"]
 # icelite = true
 
+[webrtc.timeouts]
+# The duration in [sec] without network activity before a ICE Agent is considered disconnected
+disconnected = 5
+# The duration in [sec] without network activity before a ICE Agent is considered failed after disconnected
+failed = 25
+# How often in [sec] the ICE Agent sends extra traffic if there is no activity, if media is flowing no traffic will be sent
+keepalive = 2
+
 [turn]
 # Enables embeded turn server
 enabled = false

--- a/pkg/sfu/sfu.go
+++ b/pkg/sfu/sfu.go
@@ -143,11 +143,17 @@ func NewWebRTCTransportConfig(c Config) WebRTCTransportConfig {
 		sdpSemantics = webrtc.SDPSemanticsPlanB
 	}
 
-	se.SetICETimeouts(
-		time.Duration(c.WebRTC.Timeouts.ICEDisconnectedTimeout)*time.Second,
-		time.Duration(c.WebRTC.Timeouts.ICEFailedTimeout)*time.Second,
-		time.Duration(c.WebRTC.Timeouts.ICEKeepaliveInterval)*time.Second,
-	)
+	if c.WebRTC.Timeouts.ICEDisconnectedTimeout == 0 &&
+		c.WebRTC.Timeouts.ICEFailedTimeout == 0 &&
+		c.WebRTC.Timeouts.ICEKeepaliveInterval == 0 {
+		Logger.Info("No webrtc timeouts found in config, using default ones")
+	} else {
+		se.SetICETimeouts(
+			time.Duration(c.WebRTC.Timeouts.ICEDisconnectedTimeout)*time.Second,
+			time.Duration(c.WebRTC.Timeouts.ICEFailedTimeout)*time.Second,
+			time.Duration(c.WebRTC.Timeouts.ICEKeepaliveInterval)*time.Second,
+		)
+	}
 
 	w := WebRTCTransportConfig{
 		Configuration: webrtc.Configuration{

--- a/pkg/sfu/sfu.go
+++ b/pkg/sfu/sfu.go
@@ -42,14 +42,21 @@ type WebRTCTransportConfig struct {
 	BufferFactory *buffer.Factory
 }
 
+type WebRTCTimeoutsConfig struct {
+	ICEDisconnectedTimeout int `mapstructure:"disconnected"`
+	ICEFailedTimeout       int `mapstructure:"failed"`
+	ICEKeepaliveInterval   int `mapstructure:"keepalive"`
+}
+
 // WebRTCConfig defines parameters for ice
 type WebRTCConfig struct {
-	ICESinglePort int               `mapstructure:"singleport"`
-	ICEPortRange  []uint16          `mapstructure:"portrange"`
-	ICEServers    []ICEServerConfig `mapstructure:"iceserver"`
-	Candidates    Candidates        `mapstructure:"candidates"`
-	SDPSemantics  string            `mapstructure:"sdpsemantics"`
-	MDNS          bool              `mapstructure:"mdns"`
+	ICESinglePort int                  `mapstructure:"singleport"`
+	ICEPortRange  []uint16             `mapstructure:"portrange"`
+	ICEServers    []ICEServerConfig    `mapstructure:"iceserver"`
+	Candidates    Candidates           `mapstructure:"candidates"`
+	SDPSemantics  string               `mapstructure:"sdpsemantics"`
+	MDNS          bool                 `mapstructure:"mdns"`
+	Timeouts      WebRTCTimeoutsConfig `mapstructure:"timeouts"`
 }
 
 // Config for base SFU
@@ -135,6 +142,12 @@ func NewWebRTCTransportConfig(c Config) WebRTCTransportConfig {
 	case "plan-b":
 		sdpSemantics = webrtc.SDPSemanticsPlanB
 	}
+
+	se.SetICETimeouts(
+		time.Duration(c.WebRTC.Timeouts.ICEDisconnectedTimeout)*time.Second,
+		time.Duration(c.WebRTC.Timeouts.ICEFailedTimeout)*time.Second,
+		time.Duration(c.WebRTC.Timeouts.ICEKeepaliveInterval)*time.Second,
+	)
 
 	w := WebRTCTransportConfig{
 		Configuration: webrtc.Configuration{

--- a/pkg/sfu/sfu_test.go
+++ b/pkg/sfu/sfu_test.go
@@ -134,13 +134,6 @@ func addMedia(done <-chan struct{}, t *testing.T, pc *webrtc.PeerConnection, med
 func newTestConfig() Config {
 	return Config{
 		Router: RouterConfig{MaxPacketTrack: 200},
-		WebRTC: WebRTCConfig{
-			Timeouts: WebRTCTimeoutsConfig{
-				ICEDisconnectedTimeout: 5,
-				ICEFailedTimeout:       25,
-				ICEKeepaliveInterval:   2,
-			},
-		},
 	}
 }
 

--- a/pkg/sfu/sfu_test.go
+++ b/pkg/sfu/sfu_test.go
@@ -131,14 +131,24 @@ func addMedia(done <-chan struct{}, t *testing.T, pc *webrtc.PeerConnection, med
 	return senders
 }
 
+func newTestConfig() Config {
+	return Config{
+		Router: RouterConfig{MaxPacketTrack: 200},
+		WebRTC: WebRTCConfig{
+			Timeouts: WebRTCTimeoutsConfig{
+				ICEDisconnectedTimeout: 5,
+				ICEFailedTimeout:       25,
+				ICEKeepaliveInterval:   2,
+			},
+		},
+	}
+}
+
 func TestSFU_SessionScenarios(t *testing.T) {
 	logger.SetGlobalOptions(logger.GlobalConfig{V: 2}) // 2 - TRACE
 	Logger = logger.New()
-	sfu := NewSFU(
-		Config{
-			Router: RouterConfig{MaxPacketTrack: 200},
-		},
-	)
+	config := newTestConfig()
+	sfu := NewSFU(config)
 	sfu.NewDatachannel(APIChannelLabel)
 	tests := []struct {
 		name  string


### PR DESCRIPTION
#### Description

Allows configuring `webrtc.SettingEngine` timeouts. Default values don't work for all cases. For example, during debug session, it would be great to increase timeouts to be able to stop client application in the debugger and keep connections opened to be able to resume.
