### PR TITLE
pli throttling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,9 @@ audiolevelinterval=1000
 # calculated as audiolevelinterval/packetization time (20ms for 8kHz)
 # Values from [0-100]
 audiolevelfilter = 20
+# Sets the minimum throttling duration in [ms] between PLIs
+# forwarded to each WebRTCReceiver.
+plithrottle = 500
 
 [router.simulcast]
 # Prefer best quality initially

--- a/go.sum
+++ b/go.sum
@@ -210,7 +210,6 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -379,7 +378,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -7,10 +7,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pion/ion-sfu/pkg/buffer"
 	"github.com/pion/rtcp"
 	"github.com/pion/transport/packetio"
 	"github.com/pion/webrtc/v3"
+
+	"github.com/pion/ion-sfu/pkg/buffer"
 )
 
 // DownTrackType determines the type of a track
@@ -94,7 +95,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 		d.payloadType = uint8(codec.PayloadType)
 		d.writeStream = t.WriteStream()
 		d.mime = strings.ToLower(codec.MimeType)
-		d.reSync.set(true)
 		d.reBaseTs.set(true)
 		d.enabled.set(true)
 		if rr := d.bufferFactory.GetOrNew(packetio.RTCPBufferPacket, uint32(t.SSRC())).(*buffer.RTCPReader); rr != nil {

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -27,6 +27,7 @@ type RouterConfig struct {
 	AudioLevelThreshold uint8           `mapstructure:"audiolevelthreshold"`
 	AudioLevelFilter    int             `mapstructure:"audiolevelfilter"`
 	Simulcast           SimulcastConfig `mapstructure:"simulcast"`
+	PliThrottle         int64           `mapstructure:"plithrottle"`
 }
 
 type router struct {
@@ -147,7 +148,7 @@ func (r *router) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRe
 
 	recv, ok := r.receivers[trackID]
 	if !ok {
-		recv = NewWebRTCReceiver(receiver, track, r.id)
+		recv = NewWebRTCReceiver(receiver, track, r.id, WithPliThrottle(r.config.PliThrottle * 1e6))
 		r.receivers[trackID] = recv
 		recv.SetRTCPCh(r.rtcpCh)
 		recv.OnCloseHandler(func() {


### PR DESCRIPTION
#### Description

Currently, the WebRTCReceiver throttles PLIs every 500ms, however if multiple are requested within 500ms only the first one is sent - this means if one client requests it 490ms after another, the second will get dropped. This update keeps the same throttling period but will send a pli at the end of the period if another was requested. 

It also adds the duration as a router config variable.
