### PR TITLE
fix(sfu): remove race condition for session & peer

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -210,7 +210,6 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -379,7 +378,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/pkg/sfu/helpers.go
+++ b/pkg/sfu/helpers.go
@@ -15,12 +15,11 @@ const (
 
 type atomicBool int32
 
-func (a *atomicBool) set(value bool) {
-	var i int32
+func (a *atomicBool) set(value bool) (swapped bool) {
 	if value {
-		i = 1
+		return atomic.SwapInt32((*int32)(a), 1) == 0
 	}
-	atomic.StoreInt32((*int32)(a), i)
+	return atomic.SwapInt32((*int32)(a), 0) == 1
 }
 
 func (a *atomicBool) get() bool {

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -268,7 +268,9 @@ func (p *PeerLocal) Close() error {
 	p.Lock()
 	defer p.Unlock()
 
-	p.closed.set(true)
+	if !p.closed.set(true) {
+		return nil
+	}
 
 	if p.session != nil {
 		p.session.RemovePeer(p)

--- a/pkg/sfu/publisher.go
+++ b/pkg/sfu/publisher.go
@@ -209,9 +209,8 @@ func (p *Publisher) Relay(ice []webrtc.ICEServer) (*relay.Peer, error) {
 			}
 		}
 		p.relayPeer = append(p.relayPeer, rp)
-
-		go p.relayReports(rp)
 		p.mu.Unlock()
+		go p.relayReports(rp)
 	})
 
 	if err = rp.Offer(p.cfg.Relay); err != nil {

--- a/pkg/sfu/sfu.go
+++ b/pkg/sfu/sfu.go
@@ -270,8 +270,12 @@ func (s *SFU) NewDatachannel(label string) *Datachannel {
 }
 
 // GetSessions return all sessions
-func (s *SFU) GetSessions() map[string]Session {
+func (s *SFU) GetSessions() []Session {
 	s.RLock()
 	defer s.RUnlock()
-	return s.sessions
+	sessions := make([]Session, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		sessions = append(sessions, session)
+	}
+	return sessions
 }

--- a/pkg/sfu/subscriber.go
+++ b/pkg/sfu/subscriber.go
@@ -98,6 +98,8 @@ func (s *Subscriber) AddDatachannel(peer Peer, dc *Datachannel) error {
 
 // DataChannel returns the channel for a label
 func (s *Subscriber) DataChannel(label string) *webrtc.DataChannel {
+	s.RLock()
+	defer s.RUnlock()
 	return s.channels[label]
 }
 
@@ -204,11 +206,13 @@ func (s *Subscriber) SetRemoteDescription(desc webrtc.SessionDescription) error 
 }
 
 func (s *Subscriber) RegisterDatachannel(label string, dc *webrtc.DataChannel) {
+	s.Lock()
 	s.channels[label] = dc
+	s.Unlock()
 }
 
 func (s *Subscriber) GetDatachannel(label string) *webrtc.DataChannel {
-	return s.channels[label]
+	return s.DataChannel(label)
 }
 
 func (s *Subscriber) GetDownTracks(streamID string) []*DownTrack {


### PR DESCRIPTION
#### Description
After network disruption, client may restart signaling with the same uid. It is possible that new AddPeer is called before RemovePeer in the exiting goroutine that delete the newly created one.

This fix also prevents duplicated NewSession in race condition. Also fixes GetSessions that the returned map is not thread-safe.