### PR TITLE
[fix] Add gate on conf.NoSubscribe before calling subscriber.AddDatachannel in PeerLocal join

### DIFF
--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -146,9 +146,11 @@ func (p *PeerLocal) Join(sid, uid string, config ...JoinConfig) error {
 		if err != nil {
 			return fmt.Errorf("error creating transport: %v", err)
 		}
-		for _, dc := range p.session.GetDCMiddlewares() {
-			if err := p.subscriber.AddDatachannel(p, dc); err != nil {
-				return fmt.Errorf("setting subscriber default dc datachannel: %w", err)
+		if !conf.NoSubscribe {
+			for _, dc := range p.session.GetDCMiddlewares() {
+				if err := p.subscriber.AddDatachannel(p, dc); err != nil {
+					return fmt.Errorf("setting subscriber default dc datachannel: %w", err)
+				}
 			}
 		}
 

--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -296,7 +296,7 @@ func (s *SessionLocal) GetDataChannels(origin, label string) (dcs []*webrtc.Data
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for pid, p := range s.peers {
-		if origin == pid {
+		if origin == pid || p.Subscriber() == nil {
 			continue
 		}
 


### PR DESCRIPTION
I receive this panic when adding a peer with `JoinConfig` `{ NoPublish: false, NoSubscribe: true }`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe30368]

goroutine 122 [running]:
github.com/pion/ion-sfu/pkg/sfu.(*Subscriber).AddDatachannel(0x0, 0x1381400, 0xc0001c0000, 0xc000358d50, 0xc0002aae00, 0xc000168840)
/go/pkg/mod/github.com/consumer/ion-sfu@v1.9.9-0.20210622161950-cffd0dbc3d4e/pkg/sfu/subscriber.go:75 +0x68
github.com/pion/ion-sfu/pkg/sfu.(*PeerLocal).Join(0xc0001c0000, 0xc0000a0150, 0x24, 0xc00022c780, 0x48, 0xc0001895b6, 0x1, 0x1, 0x0, 0xc000189610)
/go/pkg/mod/github.com/consumer/ion-sfu@v1.9.9-0.20210622161950-cffd0dbc3d4e/pkg/sfu/peer.go:150 +0x871
```