### PR TITLE
Use sequence parameter sets for h.264 keyframe detection

### DIFF
--- a/pkg/buffer/helpers.go
+++ b/pkg/buffer/helpers.go
@@ -163,7 +163,7 @@ func isH264Keyframe(payload []byte) bool {
 				return false
 			}
 			n := payload[i+offset] & 0x1F
-			if n == 5 {
+			if n == 7 {
 				return true
 			} else if n >= 24 {
 				// is this legal?
@@ -184,7 +184,7 @@ func isH264Keyframe(payload []byte) bool {
 			// not a starting fragment
 			return false
 		}
-		return payload[1]&0x1F == 5
+		return payload[1]&0x1F == 7
 	}
 	return false
 }


### PR DESCRIPTION
Similar to the change made in Galene by jech, use SPS to detect keyframes. This fixes glitches in H.264 when layer switching

https://github.com/jech/galene/commit/4435a30a539a97c4dc2c062f19c6ff54b3930035

