### PR TITLE
Add NoAutoSubscribe to peer.JoinConfig.

### DIFF
--- a/cmd/signal/grpc/server/server.go
+++ b/cmd/signal/grpc/server/server.go
@@ -149,10 +149,12 @@ func (s *SFUServer) Signal(stream pb.SFU_SignalServer) error {
 
 			_, nopub := payload.Join.Config["NoPublish"]
 			_, nosub := payload.Join.Config["NoSubscribe"]
+			_, noautosub := payload.Join.Config["NoAutoSubscribe"]
 
 			cfg := sfu.JoinConfig{
-				NoPublish:   nopub,
-				NoSubscribe: nosub,
+				NoPublish:       nopub,
+				NoSubscribe:     nosub,
+				NoAutoSubscribe: noautosub,
 			}
 			err = peer.Join(payload.Join.Sid, payload.Join.Uid, cfg)
 			if err != nil {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -161,6 +161,10 @@ func (d *DownTrack) WriteRTP(p *buffer.ExtPacket) error {
 	return nil
 }
 
+func (d *DownTrack) Enabled() bool {
+	return d.enabled.get()
+}
+
 // Mute enables or disables media forwarding
 func (d *DownTrack) Mute(val bool) {
 	if d.enabled.get() != val {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -143,6 +143,10 @@ func (d *DownTrack) Kind() webrtc.RTPCodecType {
 	}
 }
 
+func (d *DownTrack) Stop() error {
+	return d.transceiver.Stop()
+}
+
 func (d *DownTrack) SetTransceiver(transceiver *webrtc.RTPTransceiver) {
 	d.transceiver = transceiver
 }

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -144,7 +144,10 @@ func (d *DownTrack) Kind() webrtc.RTPCodecType {
 }
 
 func (d *DownTrack) Stop() error {
-	return d.transceiver.Stop()
+	if d.transceiver != nil {
+		return d.transceiver.Stop()
+	}
+	return fmt.Errorf("d.transceiver not exists")
 }
 
 func (d *DownTrack) SetTransceiver(transceiver *webrtc.RTPTransceiver) {

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -39,6 +39,11 @@ type JoinConfig struct {
 	NoPublish bool
 	// If true the peer will not be allowed to subscribe to other peers in SessionLocal.
 	NoSubscribe bool
+	// If true the peer will not automatically subscribe all tracks,
+	// and then the peer can use peer.Subscriber().AddDownTrack/RemoveDownTrack
+	// to customize the subscrbe stream combination as needed.
+	// this parameter depends on NoSubscribe=false.
+	NoAutoSubscribe bool
 }
 
 // SessionProvider provides the SessionLocal to the sfu.Peer
@@ -104,6 +109,8 @@ func (p *PeerLocal) Join(sid, uid string, config ...JoinConfig) error {
 		if err != nil {
 			return fmt.Errorf("error creating transport: %v", err)
 		}
+
+		p.subscriber.noAutoSubscribe = conf.NoAutoSubscribe
 
 		p.subscriber.OnNegotiationNeeded(func() {
 			p.Lock()

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -71,6 +71,7 @@ type PeerLocal struct {
 	OnOffer                    func(*webrtc.SessionDescription)
 	OnIceCandidate             func(*webrtc.ICECandidateInit, int)
 	OnICEConnectionStateChange func(webrtc.ICEConnectionState)
+	OnPublisherTrack           func(PublisherTrack)
 
 	remoteAnswerPending bool
 	negotiationPending  bool

--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -71,7 +71,6 @@ type PeerLocal struct {
 	OnOffer                    func(*webrtc.SessionDescription)
 	OnIceCandidate             func(*webrtc.ICECandidateInit, int)
 	OnICEConnectionStateChange func(webrtc.ICEConnectionState)
-	OnPublisherTrack           func(PublisherTrack)
 
 	remoteAnswerPending bool
 	negotiationPending  bool

--- a/pkg/sfu/subscriber.go
+++ b/pkg/sfu/subscriber.go
@@ -218,12 +218,12 @@ func (s *Subscriber) GetDatachannel(label string) *webrtc.DataChannel {
 	return s.DataChannel(label)
 }
 
-func (s *Subscriber) DownTracks() map[string][]*DownTrack {
+func (s *Subscriber) DownTracks() []*DownTrack {
 	s.RLock()
 	defer s.RUnlock()
-	downTracks := make(map[string][]*DownTrack)
-	for streamID, tracks := range s.tracks {
-		downTracks[streamID] = tracks
+	var downTracks []*DownTrack
+	for _, tracks := range s.tracks {
+		downTracks = append(downTracks, tracks...)
 	}
 	return downTracks
 }

--- a/pkg/sfu/subscriber.go
+++ b/pkg/sfu/subscriber.go
@@ -26,6 +26,8 @@ type Subscriber struct {
 
 	negotiate func()
 	closeOnce sync.Once
+
+	noAutoSubscribe bool
 }
 
 // NewSubscriber creates a new Subscriber
@@ -44,11 +46,12 @@ func NewSubscriber(id string, cfg WebRTCTransportConfig) (*Subscriber, error) {
 	}
 
 	s := &Subscriber{
-		id:       id,
-		me:       me,
-		pc:       pc,
-		tracks:   make(map[string][]*DownTrack),
-		channels: make(map[string]*webrtc.DataChannel),
+		id:              id,
+		me:              me,
+		pc:              pc,
+		tracks:          make(map[string][]*DownTrack),
+		channels:        make(map[string]*webrtc.DataChannel),
+		noAutoSubscribe: false,
 	}
 
 	pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
@@ -213,6 +216,16 @@ func (s *Subscriber) RegisterDatachannel(label string, dc *webrtc.DataChannel) {
 
 func (s *Subscriber) GetDatachannel(label string) *webrtc.DataChannel {
 	return s.DataChannel(label)
+}
+
+func (s *Subscriber) DownTracks() map[string][]*DownTrack {
+	s.RLock()
+	defer s.RUnlock()
+	downTracks := make(map[string][]*DownTrack)
+	for streamID, tracks := range s.tracks {
+		downTracks[streamID] = tracks
+	}
+	return downTracks
 }
 
 func (s *Subscriber) GetDownTracks(streamID string) []*DownTrack {


### PR DESCRIPTION
#### Description
Do not subscribe to any stream during peer join, so that the application layer can perform fine control and subscribe on-demand

1, Listen publisher.OnPublishTrack event, generate StreamEvent and broadcast to each peer.
```go
peer.Publisher().OnPublisherTrack(func(track ion_sfu.PublisherTrack) {
    log.Debugf("peer.OnPublisherTrack: \nKind %v, \nUid: %v,  \nMsid: %v,\nTrackID: %v",
                       track.Track.Kind(),
                       uid, 
                       track.Track.Msid(), 
                       track.Track.ID())
    // event := &rtc.StreamEvent{.....}
    // sig.BroadcastStreamEvent(event)
})
```

2,Peer uses the trackIds in StreamEvent to subscribe or unsubscribe.
```go
case *rtc.UpdateSettings_Subcription:

subscription := payload.UpdateSettings.GetSubcription()
enabled := subscription.GetSubscribe()

for _, trackId := range subscription.TrackIds {

	if enabled {
                 // Add down tracks
		for _, p := range peer.Session().Peers() {
			for _, track := range p.Publisher().PublisherTracks() {
				if track.Receiver.TrackID() == trackId {
					peer.Publisher().GetRouter().AddDownTrack(peer.Subscriber(), track.Receiver)
				}
			}
		}
	} else {
               // Remove down tracks
		for streamID, downTracks := range peer.Subscriber().DownTracks() {
			for _,  track := range downTracks {
				if track.ID() == trackId {
					peer.Subscriber().RemoveDownTrack(streamID, track)
                                          track.Stop()
				}
			}
		}
	}

}

peer.Subscriber().Negotiate()
```
