### PR TITLE
Fixed jsonrpc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ http://localhost:8000/
 
 ### SFU with json-rpc signaling
 
-The json-rpc signaling service can be used to easily get up and running with the sfu. It can be used with the [corresponding javascript signaling module](https://github.com/pion/ion-sdk-js/blob/master/src/signal/ion-sfu.ts).
+The json-rpc signaling service can be used to easily get up and running with the sfu. It can be used with the [corresponding javascript signaling module](https://github.com/pion/ion-sdk-js/blob/master/src/signal/json-rpc-impl.ts).
 
 ##### Using golang environment
 


### PR DESCRIPTION
#### Description

A path in the [ion-sdk-js](https://github.com/pion/ion-sdk-js) repository seems to have changed, and the README link is invalid.

#### Reference issue
Fixes #549 
