### PR TITLE
Add notification to the middleware of peer removal.

### DIFF
--- a/pkg/sfu/datachannel.go
+++ b/pkg/sfu/datachannel.go
@@ -14,6 +14,7 @@ type (
 		Label       string
 		middlewares []func(MessageProcessor) MessageProcessor
 		onMessage   func(ctx context.Context, args ProcessArgs)
+		onRemovePeer func( peer Peer )
 	}
 
 	ProcessArgs struct {
@@ -47,6 +48,10 @@ func (dc *Datachannel) Use(middlewares ...func(MessageProcessor) MessageProcesso
 // after all the middlewares have processed the message.
 func (dc *Datachannel) OnMessage(fn func(ctx context.Context, args ProcessArgs)) {
 	dc.onMessage = fn
+}
+
+func (dc *Datachannel) OnRemovePeer(fn func(peer Peer)) {
+	dc.onRemovePeer = fn
 }
 
 func (p ProcessFunc) Process(ctx context.Context, args ProcessArgs) {

--- a/pkg/sfu/subscriber.go
+++ b/pkg/sfu/subscriber.go
@@ -93,6 +93,11 @@ func (s *Subscriber) AddDatachannel(peer Peer, dc *Datachannel) error {
 			DataChannel: ndc,
 		})
 	})
+	ndc.OnClose(func() {
+		if dc.onRemovePeer != nil {
+			dc.onRemovePeer( peer )
+		}
+	})
 
 	s.channels[dc.Label] = ndc
 


### PR DESCRIPTION
#### Description

This change allows data channel middleware to register a callback for when a peer disconnects.

#### Reference issue
Fixes #572 
