### PR TITLE
feat(relay):Audioobserver supported on relaying SFU

### DIFF
--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -165,6 +165,13 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, o Options) {
 			}
 		}
 	} else if b.codecType == webrtc.RTPCodecTypeAudio {
+		if len(params.HeaderExtensions) == 0 {
+			t := &webrtc.RTPHeaderExtensionParameter{
+				URI: "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+				ID:  1,
+			}
+			params.HeaderExtensions = append(params.HeaderExtensions, *t)
+		}
 		for _, h := range params.HeaderExtensions {
 			if h.URI == sdp.AudioLevelURI {
 				b.audioLevel = true


### PR DESCRIPTION
If we relay audio track  by ortc  api,the sdp has no RTPHeader "urn:ietf:params:rtp-hdrext:ssrc-audio-level", so the relaying sfu can not observer the relayed audio track.
