### PR TITLE
Fix error msg to match jsonrpc method

### DIFF
--- a/cmd/signal/json-rpc/server/server.go
+++ b/cmd/signal/json-rpc/server/server.go
@@ -107,7 +107,7 @@ func (p *JSONSignal) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 		var negotiation Negotiation
 		err := json.Unmarshal(*req.Params, &negotiation)
 		if err != nil {
-			p.Logger.Error(err, "connect: error parsing offer")
+			p.Logger.Error(err, "connect: error parsing answer")
 			replyError(err)
 			break
 		}


### PR DESCRIPTION
I think the error message should complain indicate failure to parse the "answer" instead of "offer" because this case handles an incoming answer.