### PR TITLE
Fix subscriber nil dereferencing

### DIFF
--- a/cmd/signal/grpc/server/server.go
+++ b/cmd/signal/grpc/server/server.go
@@ -90,6 +90,10 @@ func (s *SFUServer) Signal(sig rtc.RTC_SignalServer) error {
 			}
 
 			// Remove down tracks that other peers subscribed from this peer
+			subscriber := peer.Subscriber()
+			if subscriber == nil {
+				return
+			}
 			for _, downTrack := range peer.Subscriber().DownTracks() {
 				streamID := downTrack.StreamID()
 				for _, t := range tracksInfo {

--- a/cmd/signal/grpc/server/server.go
+++ b/cmd/signal/grpc/server/server.go
@@ -94,7 +94,7 @@ func (s *SFUServer) Signal(sig rtc.RTC_SignalServer) error {
 			if subscriber == nil {
 				return
 			}
-			for _, downTrack := range peer.Subscriber().DownTracks() {
+			for _, downTrack := range subscriber.DownTracks() {
 				streamID := downTrack.StreamID()
 				for _, t := range tracksInfo {
 					if downTrack != nil && downTrack.ID() == t.Id {


### PR DESCRIPTION
#### Description
The subscriber may be nil when fetching the peer.

#### Reference issue
Fixes #623 