### PR TITLE
Fix broken links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For "batteries-included", end-to-end solutions that are easier to deploy, check 
 Run the Echo Test example
 
 ```
-docker-compose -f examples/echotest/docker-compose.yaml up
+docker-compose -f examples/echotest-jsonrpc/docker-compose.yaml up
 ```
 
 Open the client

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,4 +10,4 @@ Please feel free to extend and add additional examples!
 
 ### Overview
 
-* [echotest](echotest): Demonstrates how to establish a connection to `ion-sfu` as well as publish and receive a video stream.
+* [echotest](echotest-jsonrpc): Demonstrates how to establish a connection to `ion-sfu` as well as publish and receive a video stream.


### PR DESCRIPTION
Some links weren't available due to renaming example directory (echotest -> echotest-jsonrpc).

Now they are available.
