### PR TITLE
[FIX]  Datachannle already exists

### DIFF
--- a/pkg/sfu/session.go
+++ b/pkg/sfu/session.go
@@ -161,6 +161,9 @@ func (s *SessionLocal) AddDatachannel(owner string, dc *webrtc.DataChannel) {
 	s.mu.Lock()
 	for _, lbl := range s.fanOutDCs {
 		if label == lbl {
+			dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+				s.FanOutMessage(owner, label, msg)
+			})
 			s.mu.Unlock()
 			return
 		}


### PR DESCRIPTION
#### Description
[FIX] When DataChannel Label already exists , The message of the new DC cannot be forwarded.
#### Reference issue
Fixes #...
