### PR TITLE
FIX: The creation of multiple relay datachannel failed. Procedure

### DIFF
--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -356,7 +356,7 @@ func (p *Peer) CreateDataChannel(label string) (*webrtc.DataChannel, error) {
 
 func (p *Peer) createDataChannel(label string) (*webrtc.DataChannel, error) {
 	idx := p.dcIndex
-	p.dcIndex = +1
+	p.dcIndex += 1
 	dcParams := &webrtc.DataChannelParameters{
 		Label:   label,
 		ID:      &idx,

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -356,7 +356,7 @@ func (p *Peer) CreateDataChannel(label string) (*webrtc.DataChannel, error) {
 
 func (p *Peer) createDataChannel(label string) (*webrtc.DataChannel, error) {
 	idx := p.dcIndex
-	p.dcIndex += 1
+	p.dcIndex++
 	dcParams := &webrtc.DataChannelParameters{
 		Label:   label,
 		ID:      &idx,

--- a/pkg/sfu/publisher.go
+++ b/pkg/sfu/publisher.go
@@ -231,6 +231,7 @@ func (p *Publisher) Relay(signalFn func(meta relay.PeerMeta, signal []byte) ([]b
 				dc, err := rp.CreateDataChannel(lbl)
 				if err != nil {
 					Logger.V(1).Error(err, "Creating data channels.", "peer_id", p.id)
+					continue
 				}
 				dc.OnMessage(func(msg webrtc.DataChannelMessage) {
 					if peer == nil || peer.Subscriber() == nil {


### PR DESCRIPTION
Hello my friend,
The ID in DataChannelParameters should be incremented, there are some problems with the current way of writing, it is 1 every time, I dealt with this problem, you can review it if you can.

At the same time, I found that relay does not process the Middleware Datachannel at present, so some functions implemented by ion-sfu datachannel cannot run properly under relay. I fixed this problem, and we can discuss it if necessary.