### PR TITLE
Fix crash when audio nack packets received

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -532,12 +532,14 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 				}
 			}
 		case *rtcp.TransportLayerNack:
-			var nackedPackets []packetMeta
-			for _, pair := range p.Nacks {
-				nackedPackets = append(nackedPackets, d.sequencer.getSeqNoPairs(pair.PacketList())...)
-			}
-			if err = d.receiver.RetransmitPackets(d, nackedPackets); err != nil {
-				return
+			if d.sequencer != nil {
+				var nackedPackets []packetMeta
+				for _, pair := range p.Nacks {
+					nackedPackets = append(nackedPackets, d.sequencer.getSeqNoPairs(pair.PacketList())...)
+				}
+				if err = d.receiver.RetransmitPackets(d, nackedPackets); err != nil {
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Description

If client sent rtcp.TransportLayerNack to audio downtrack,
ion-sfu going crash because downTrack.sequencer is only allocated for video track.
Check sequencer is nil when rtcp.TransportLayerNack has arrived.

#### Reference issue
Fixes #...
