### PR TITLE
Fix(receiver): Fix that Close method is not called when downtrack is deleted.

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -178,7 +178,7 @@ func (w *WebRTCReceiver) AddDownTrack(track *DownTrack, bestQualityFirst bool) {
 				}
 			}
 		}
-		if w.downTrackSubscribed(layer, track) {
+		if w.isDownTrackSubscribed(layer, track) {
 			return
 		}
 		track.SetInitialLayers(int32(layer), 2)
@@ -188,7 +188,7 @@ func (w *WebRTCReceiver) AddDownTrack(track *DownTrack, bestQualityFirst bool) {
 		track.trackType = SimulcastDownTrack
 		track.payload = packetFactory.Get().(*[]byte)
 	} else {
-		if w.downTrackSubscribed(layer, track) {
+		if w.isDownTrackSubscribed(layer, track) {
 			return
 		}
 		track.SetInitialLayers(0, 0)
@@ -254,6 +254,8 @@ func (w *WebRTCReceiver) deleteDownTrack(layer int, id string) {
 	for _, dt := range dts {
 		if dt.id != id {
 			ndts = append(ndts, dt)
+		} else {
+			dt.Close()
 		}
 	}
 	w.downTracks[layer].Store(ndts)
@@ -396,7 +398,7 @@ func (w *WebRTCReceiver) closeTracks() {
 	}
 }
 
-func (w *WebRTCReceiver) downTrackSubscribed(layer int, dt *DownTrack) bool {
+func (w *WebRTCReceiver) isDownTrackSubscribed(layer int, dt *DownTrack) bool {
 	dts := w.downTracks[layer].Load().([]*DownTrack)
 	for _, cdt := range dts {
 		if cdt == dt {


### PR DESCRIPTION
#### Description

onCloseHandler of downtrack was not called because close method of downtrack was called when receiver was closed and not when only downtrack was deleted.
