### PR TITLE
Fix unreachable conditional in receiver's `writeRTP`

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -370,7 +370,7 @@ func (w *WebRTCReceiver) writeRTP(layer int) {
 
 		for _, dt := range w.downTracks[layer].Load().([]*DownTrack) {
 			if err = dt.WriteRTP(pkt, layer); err != nil {
-				if err == io.EOF && err == io.ErrClosedPipe {
+				if err == io.EOF || err == io.ErrClosedPipe {
 					w.Lock()
 					w.deleteDownTrack(layer, dt.id)
 					w.Unlock()


### PR DESCRIPTION
#### Description

Currently after calling `WriteRTP` the code checks if the returned `err` is both an `io.EOF` and  an `io.ErrClosedPipe` this condition would never be satisfied & the down track would never be removed through this function


#### Reference issue
Fixes #...
