### PR TITLE
feat: added noAutoSubscribeDataChannels configuration which prevents …

### DIFF
--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -44,6 +44,10 @@ type JoinConfig struct {
 	// to customize the subscrbe stream combination as needed.
 	// this parameter depends on NoSubscribe=false.
 	NoAutoSubscribe bool
+	// If true the peer will not automatically subscribe all data channels,
+	// The peer can subscribe data channels by creating locally.
+	// this parameter depends on NoSubscribe=false.
+	NoAutoSubscribeDataChannels bool
 }
 
 // SessionProvider provides the SessionLocal to the sfu.Peer
@@ -111,6 +115,7 @@ func (p *PeerLocal) Join(sid, uid string, config ...JoinConfig) error {
 		}
 
 		p.subscriber.noAutoSubscribe = conf.NoAutoSubscribe
+		p.subscriber.noAutoSubscribeDataChannels = conf.NoAutoSubscribeDataChannels
 
 		p.subscriber.OnNegotiationNeeded(func() {
 			p.Lock()

--- a/pkg/sfu/subscriber.go
+++ b/pkg/sfu/subscriber.go
@@ -27,7 +27,8 @@ type Subscriber struct {
 	negotiate func()
 	closeOnce sync.Once
 
-	noAutoSubscribe bool
+	noAutoSubscribe             bool
+	noAutoSubscribeDataChannels bool
 }
 
 // NewSubscriber creates a new Subscriber
@@ -46,12 +47,13 @@ func NewSubscriber(id string, cfg WebRTCTransportConfig) (*Subscriber, error) {
 	}
 
 	s := &Subscriber{
-		id:              id,
-		me:              me,
-		pc:              pc,
-		tracks:          make(map[string][]*DownTrack),
-		channels:        make(map[string]*webrtc.DataChannel),
-		noAutoSubscribe: false,
+		id:                          id,
+		me:                          me,
+		pc:                          pc,
+		tracks:                      make(map[string][]*DownTrack),
+		channels:                    make(map[string]*webrtc.DataChannel),
+		noAutoSubscribe:             false,
+		noAutoSubscribeDataChannels: false,
 	}
 
 	pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {


### PR DESCRIPTION
The purpose of the newly introduced `NoAutoSubscribeDataChannels` configuration is to allow clients to opt-out of automatic subscriptions of datachannels. The user can then connect to a datachannel by creating it locally. This results in a similar effect to subscribing, in that you subscribe to a datachannel by label.

The 'NoAutoSubscribe' serves a similar purpose but, from what I can tell, is intended towards downstream tracks, so this new feature complements it nicely. 