### PR TITLE
feat: add transceiver getter to downtrack

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -150,6 +150,10 @@ func (d *DownTrack) Stop() error {
 	return fmt.Errorf("d.transceiver not exists")
 }
 
+func (d *DownTrack) GetTransceiver() *webrtc.RTPTransceiver {
+	return d.transceiver
+}
+
 func (d *DownTrack) SetTransceiver(transceiver *webrtc.RTPTransceiver) {
 	d.transceiver = transceiver
 }


### PR DESCRIPTION
Transceiver getter adds more flexibility to downtrack API, e.g. track Mid can be retrieved from downtrack. Also, transceiver setter is already present.