### PR TITLE
feat: enable new log levels

### DIFF
--- a/cmd/signal/allrpc/main.go
+++ b/cmd/signal/allrpc/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pion/ion-sfu/cmd/signal/allrpc/server"
 	log "github.com/pion/ion-sfu/pkg/logger"
 	"github.com/pion/ion-sfu/pkg/sfu"
+	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 )
 
@@ -41,7 +42,7 @@ func showHelp() {
 	fmt.Println("             {grpc and jsonrpc addrs should be set at least one}")
 	fmt.Println("      -maddr {metrics listen addr}")
 	fmt.Println("      -h (show help info)")
-	fmt.Println("      -v {0-10} (verbosity level, default 0)")
+	fmt.Println("      -v {-6,2} (verbosity level, default 0)")
 }
 
 func load() bool {
@@ -74,11 +75,6 @@ func load() bool {
 		return false
 	}
 
-	if conf.LogConfig.V < 0 {
-		logger.Error(nil, "Logger V-Level cannot be less than 0")
-		return false
-	}
-
 	logger.Info("Config file loaded", "file", file)
 	return true
 }
@@ -91,7 +87,7 @@ func parse() bool {
 	flag.StringVar(&gaddr, "gaddr", "", "grpc listening address")
 	flag.StringVar(&paddr, "paddr", "", "pprof listening address")
 	flag.StringVar(&maddr, "maddr", "", "metrics listening address")
-	flag.IntVar(&verbosityLevel, "v", -1, "verbosity level, higher value - more logs")
+	flag.IntVar(&verbosityLevel, "v", -int(zerolog.Disabled), "verbosity level, higher value - more logs")
 	help := flag.Bool("h", false, "help info")
 	flag.Parse()
 
@@ -139,8 +135,8 @@ func main() {
 		showHelp()
 		os.Exit(-1)
 	}
-	// Check that the -v is not set (default -1)
-	if verbosityLevel < 0 {
+	// Check that the -v is not set
+	if 1-verbosityLevel > int(zerolog.Disabled) {
 		verbosityLevel = conf.LogConfig.V
 	}
 

--- a/cmd/signal/grpc/main.go
+++ b/cmd/signal/grpc/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pion/ion-sfu/cmd/signal/grpc/server"
 	"github.com/pion/ion-sfu/pkg/middlewares/datachannel"
+	"github.com/rs/zerolog"
 
 	log "github.com/pion/ion-sfu/pkg/logger"
 	"github.com/pion/ion-sfu/pkg/sfu"
@@ -56,7 +57,7 @@ func showHelp() {
 	fmt.Println("      -cert {cert file}")
 	fmt.Println("      -key {key file}")
 	fmt.Println("      -h (show help info)")
-	fmt.Println("      -v {0-10} (verbosity level, default 0)")
+	fmt.Println("      -v {-6,2} (verbosity level, default 0)")
 	fmt.Println("      -paddr {pprof listen addr}")
 
 }
@@ -107,7 +108,7 @@ func parse() bool {
 	flag.StringVar(&cert, "cert", "", "cert file")
 	flag.StringVar(&key, "key", "", "key file")
 	flag.StringVar(&metricsAddr, "m", ":8100", "merics to use")
-	flag.IntVar(&verbosityLevel, "v", -1, "verbosity level, higher value - more logs")
+	flag.IntVar(&verbosityLevel, "v", -int(zerolog.Disabled), "verbosity level, higher value - more logs")
 	flag.StringVar(&paddr, "paddr", "", "pprof listening address")
 	help := flag.Bool("h", false, "help info")
 	flag.Parse()
@@ -161,8 +162,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// Check that the -v is not set (default -1)
-	if verbosityLevel < 0 {
+	// Check that the -v is not set
+	if 1-verbosityLevel > int(zerolog.Disabled) {
 		verbosityLevel = conf.LogConfig.V
 	}
 

--- a/cmd/signal/json-rpc/main.go
+++ b/cmd/signal/json-rpc/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pion/ion-sfu/pkg/middlewares/datachannel"
 	"github.com/pion/ion-sfu/pkg/sfu"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 	"github.com/sourcegraph/jsonrpc2"
 	websocketjsonrpc2 "github.com/sourcegraph/jsonrpc2/websocket"
 	"github.com/spf13/viper"
@@ -48,7 +49,7 @@ func showHelp() {
 	fmt.Println("      -key {key file}")
 	fmt.Println("      -a {listen addr}")
 	fmt.Println("      -h (show help info)")
-	fmt.Println("      -v {0-10} (verbosity level, default 0)")
+	fmt.Println("      -v {-6,2} (verbosity level, default 0)")
 }
 
 func load() bool {
@@ -86,11 +87,6 @@ func load() bool {
 		return false
 	}
 
-	if logConfig.Config.V < 0 {
-		logger.Error(nil, "Logger V-Level cannot be less than 0")
-		return false
-	}
-
 	logger.V(0).Info("Config file loaded", "file", file)
 	return true
 }
@@ -101,7 +97,7 @@ func parse() bool {
 	flag.StringVar(&key, "key", "", "key file")
 	flag.StringVar(&addr, "a", ":7000", "address to use")
 	flag.StringVar(&metricsAddr, "m", ":8100", "merics to use")
-	flag.IntVar(&verbosityLevel, "v", -1, "verbosity level, higher value - more logs")
+	flag.IntVar(&verbosityLevel, "v", -int(zerolog.Disabled), "verbosity level, higher value - more logs")
 	help := flag.Bool("h", false, "help info")
 	flag.Parse()
 	if !load() {
@@ -142,8 +138,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// Check that the -v is not set (default -1)
-	if verbosityLevel < 0 {
+	if 1-verbosityLevel > int(zerolog.Disabled) {
 		verbosityLevel = logConfig.Config.V
 	}
 

--- a/pkg/logger/zerologr.go
+++ b/pkg/logger/zerologr.go
@@ -56,7 +56,7 @@ func SetGlobalOptions(config GlobalConfig) {
 	lvl := 1 - config.V
 	if v := int(zerolog.TraceLevel); lvl < v {
 		lvl = v
-	} else if v := int(zerolog.InfoLevel); lvl > v {
+	} else if v := int(zerolog.Disabled); lvl > v {
 		lvl = v
 	}
 	zerolog.SetGlobalLevel(zerolog.Level(lvl))


### PR DESCRIPTION
#### Description
Currently there are only three log levels available: INFO (`-v 0`), DEBUG (`-v 1`) and TRACE (`-v 2`). This PR adds all other levels, from DISABLED (`-v 6`) up to TRACE (`-v 2`). It does not break existing SFU configs.
