### PR TITLE
fix: Trickle for Sub or Pub only Peers

### DIFF
--- a/pkg/sfu/peer.go
+++ b/pkg/sfu/peer.go
@@ -237,16 +237,22 @@ func (p *PeerLocal) SetRemoteDescription(sdp webrtc.SessionDescription) error {
 
 // Trickle candidates available for this peer
 func (p *PeerLocal) Trickle(candidate webrtc.ICECandidateInit, target int) error {
-	if p.subscriber == nil || p.publisher == nil {
+	if p.subscriber == nil && p.publisher == nil {
 		return ErrNoTransportEstablished
 	}
 	Logger.V(0).Info("PeerLocal trickle", "peer_id", p.id)
 	switch target {
 	case publisher:
+		if p.publisher == nil {
+			return ErrNoTransportEstablished
+		}
 		if err := p.publisher.AddICECandidate(candidate); err != nil {
 			return fmt.Errorf("setting ice candidate: %w", err)
 		}
 	case subscriber:
+		if p.subscriber == nil {
+			return ErrNoTransportEstablished
+		}
 		if err := p.subscriber.AddICECandidate(candidate); err != nil {
 			return fmt.Errorf("setting ice candidate: %w", err)
 		}


### PR DESCRIPTION
Currently when joining with a publish or subscribe only peer local the trickle function will error. This is due to a flaw in the boolean logic check at the beginning of the function. This PR fixes that bug and allows for Pub or Sub only PeerLocals with Trickle ice.